### PR TITLE
Change to using libyaml-dev, to speed up pyyaml

### DIFF
--- a/dockerfiles/lucid/Dockerfile
+++ b/dockerfiles/lucid/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER John Billings <billings@yelp.com>
 RUN apt-get update
 
 RUN apt-get -y install dpkg-dev python-tox python-setuptools
-RUN apt-get -y install python2.7-dev debhelper libyaml-0-2 libcurl4-openssl-dev
+RUN apt-get -y install python2.7-dev debhelper libyaml-dev libcurl4-openssl-dev
 
 # Make sure we get a package suitable for building this package correctly.
 # Per dnephin we need https://github.com/spotify/dh-virtualenv/pull/20

--- a/dockerfiles/trusty/Dockerfile
+++ b/dockerfiles/trusty/Dockerfile
@@ -5,7 +5,7 @@ RUN rm -f /etc/apt/sources.list.d/proposed.list
 RUN apt-get update && apt-get -y install \
 	debhelper \
 	dpkg-dev \
-	libyaml-0-2 \
+	libyaml-dev \
 	libcurl4-openssl-dev \
 	python-dev \
 	python-tox \


### PR DESCRIPTION
If we have to build our own wheel, we need libyaml-dev headers in order
to get C accelerated yaml parsing.
