### PR TITLE
Use c yaml bindings

### DIFF
--- a/dockerfiles/itest/itest/Dockerfile.lucid
+++ b/dockerfiles/itest/itest/Dockerfile.lucid
@@ -24,9 +24,10 @@ ADD habitat /nail/etc/habitat
 ADD ecosystem /nail/etc/ecosystem
 ADD region /nail/etc/region
 ADD itest.py /itest.py
+ADD run_itest.sh /run_itest.sh
 
 # configure_synapse tries to restart synapse.
 # make it think it succeeded.
 RUN ln -sf /bin/true /usr/sbin/service
 
-CMD py.test /itest.py
+CMD /bin/bash /run_itest.sh

--- a/dockerfiles/itest/itest/Dockerfile.trusty
+++ b/dockerfiles/itest/itest/Dockerfile.trusty
@@ -29,9 +29,10 @@ ADD habitat /nail/etc/habitat
 ADD ecosystem /nail/etc/ecosystem
 ADD region /nail/etc/region
 ADD itest.py /itest.py
+ADD run_itest.sh /run_itest.sh
 
 # configure_synapse tries to restart synapse.
 # make it think it succeeded.
 RUN ln -sf /bin/true /usr/sbin/service
 
-CMD py.test /itest.py
+CMD /bin/bash /run_itest.sh

--- a/dockerfiles/itest/itest/itest.py
+++ b/dockerfiles/itest/itest/itest.py
@@ -77,9 +77,6 @@ SYNAPSE_ROOT_DIR = '/var/run/synapse'
 
 @pytest.yield_fixture(scope="module")
 def setup():
-    # Install synapse-tools
-    subprocess.check_call('dpkg -i /work/dist/synapse-tools_*.deb', shell=True)
-
     os.makedirs(SYNAPSE_ROOT_DIR)
 
     zk = kazoo.client.KazooClient(hosts=ZOOKEEPER_CONNECT_STRING)

--- a/dockerfiles/itest/itest/run_itest.sh
+++ b/dockerfiles/itest/itest/run_itest.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+echo "Installing synapse-tools package"
+dpkg -i /work/dist/synapse-tools_*.deb
+
+# Set -e here because the previous install should fail lacking dependencies
+# and then we can fix it here
+set -e
+apt-get -y install -f
+
+echo "Testing that pyyaml uses optimized cyaml parsers if present"
+/usr/share/python/synapse-tools/bin/python -c 'import yaml; assert yaml.__with_libyaml__'
+
+echo "Full integration test"
+py.test /itest.py

--- a/dockerfiles/lucid/Dockerfile
+++ b/dockerfiles/lucid/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER John Billings <billings@yelp.com>
 RUN apt-get update
 
 RUN apt-get -y install dpkg-dev python-tox python-setuptools
-RUN apt-get -y install python2.7-dev debhelper libyaml-0-2 libcurl4-openssl-dev
+RUN apt-get -y install python2.7-dev debhelper libyaml-dev libcurl4-openssl-dev
 
 # Make sure we get a package suitable for building this package correctly.
 # Per dnephin we need https://github.com/spotify/dh-virtualenv/pull/20

--- a/dockerfiles/trusty/Dockerfile
+++ b/dockerfiles/trusty/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 88ADA4A042F8DD13 &&
 RUN apt-get update && apt-get -y install \
 	debhelper \
 	dpkg-dev \
-	libyaml-0-2 \
+	libyaml-dev \
 	libcurl4-openssl-dev \
 	python-dev \
 	python-tox \

--- a/src/debian/changelog
+++ b/src/debian/changelog
@@ -1,3 +1,9 @@
+synapse-tools (0.9.2) lucid; urgency=low
+
+  * Fix pyyaml build to use c libyaml when possible
+
+ -- Joseph Lynch <jlynch@yelp.com>  Thu, 7 Jan 2016 12:06:30 -0800
+
 synapse-tools (0.9.1) lucid; urgency=low
 
   * Bump paasta-tools

--- a/src/debian/control
+++ b/src/debian/control
@@ -3,7 +3,7 @@ Maintainer: John Billings <billings@yelp.com>
 Build-Depends:
     dh-virtualenv,
 
-Depends: python2.7
+Depends: python2.7, ${shlibs:Depends}
 Package: synapse-tools
 Architecture: any
 Description: Synapse-related tools for use on Yelp machines.

--- a/src/setup.py
+++ b/src/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='synapse-tools',
-    version='0.9.1',
+    version='0.9.2',
     provides=['synapse_tools'],
     author='John Billings',
     author_email='billings@yelp.com',

--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -11,6 +11,7 @@ import tempfile
 import yaml
 from environment_tools.type_utils import get_current_location
 from paasta_tools.marathon_tools import get_all_namespaces
+from yaml import CLoader
 
 
 SYNAPSE_TOOLS_CONFIG_PATH = '/etc/synapse/synapse-tools.conf.json'
@@ -48,7 +49,7 @@ HACHECK_PORT = 6666
 
 def get_zookeeper_topology():
     with open(ZOOKEEPER_TOPOLOGY_PATH) as fp:
-        zookeeper_topology = yaml.load(fp)
+        zookeeper_topology = yaml.load(fp, Loader=CLoader)
     zookeeper_topology = [
         '%s:%d' % (entry[0], entry[1]) for entry in zookeeper_topology]
     return zookeeper_topology


### PR DESCRIPTION
The native python yaml parser is _really_ slow, so we should build
against the libyaml-dev package so that we can take advantage of c
bindings if we have them