### PR TITLE
Public package build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ dockerfiles/itest/itest_lucid/
 dockerfiles/itest/itest_trusty/
 src/debian/synapse-tools.postinst.debhelper
 src/.cache/
+bintray.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+branch:
+  only:
+    - master
 language: python
 sudo: required
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: python
+sudo: required
+services:
+  - docker
+install: pip install tox
+script: make itest_trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,12 @@ services:
   - docker
 install: pip install tox
 script: make itest_trusty
+deploy:
+  - provider: bintray
+    file: "bintray.json"
+    user: yelptravis
+    key:
+      secure: "F9DHZln0Zp1/A/ZvhXyn7ff55WAo8Df2NuS1/TZshXXbWpc5LXbxFrPHtoP5gBG+BuH7MnYzm4g0S1lECxbSs+fuiBE4C3nfnk8hXfl31o451WQQnjOhtJ0BHXoA2LqTd9gFFZETTGz6IGioP7sc0LrzJ7XR2iMaPSBGraZTvUQM5hodKIQ3Nfv2qbSbPyV4zAe54ukO4rn4lxqgTeDKjcbpU797QWokuePfvqa2wKShrtsWqW/mJ3vDKB3aimGPXC8TRXp1tEdF0jJIfX4nLO3HEnOMQgwRGu1Dk2/BlQvL+k8ZUEt2iNhkkh/ZpBIFmWC/vhj40zEAk3uPs3JTavULvCHQ81/UMJjA+fBve9INp93kvjC1udJCMn2FNF7fVj8xeVcSq7XIFzk/Buqn40b9AaMX80iow+8hJ68vm/r6U8U/K19azgmKCQWDYYtCmLmuNRi6TTQvF7ToyfQxNrgq8MNp6akCA7L0lad0IWhm/haV5wvOpem5ozuRwZgf8Yh9aryLt3NngndqEw51RC4onqyw1ytEtqCh1UDrJgzRJZuJozz0s3Yv7OZc09w9i4aRji6Tzd2mrfpKrjBJzIUFOAist1W0wzNsJu1flxAjh6pYvYp6wYeMxU1zsz808/c4cTbUHpmJYONmgzn/+zLqQiAXDIX5Ye1KgEE1bsI="
+    on:
+      tags: true
+      repo: Yelp/synapse-tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ deploy:
     key:
       secure: "F9DHZln0Zp1/A/ZvhXyn7ff55WAo8Df2NuS1/TZshXXbWpc5LXbxFrPHtoP5gBG+BuH7MnYzm4g0S1lECxbSs+fuiBE4C3nfnk8hXfl31o451WQQnjOhtJ0BHXoA2LqTd9gFFZETTGz6IGioP7sc0LrzJ7XR2iMaPSBGraZTvUQM5hodKIQ3Nfv2qbSbPyV4zAe54ukO4rn4lxqgTeDKjcbpU797QWokuePfvqa2wKShrtsWqW/mJ3vDKB3aimGPXC8TRXp1tEdF0jJIfX4nLO3HEnOMQgwRGu1Dk2/BlQvL+k8ZUEt2iNhkkh/ZpBIFmWC/vhj40zEAk3uPs3JTavULvCHQ81/UMJjA+fBve9INp93kvjC1udJCMn2FNF7fVj8xeVcSq7XIFzk/Buqn40b9AaMX80iow+8hJ68vm/r6U8U/K19azgmKCQWDYYtCmLmuNRi6TTQvF7ToyfQxNrgq8MNp6akCA7L0lad0IWhm/haV5wvOpem5ozuRwZgf8Yh9aryLt3NngndqEw51RC4onqyw1ytEtqCh1UDrJgzRJZuJozz0s3Yv7OZc09w9i4aRji6Tzd2mrfpKrjBJzIUFOAist1W0wzNsJu1flxAjh6pYvYp6wYeMxU1zsz808/c4cTbUHpmJYONmgzn/+zLqQiAXDIX5Ye1KgEE1bsI="
     on:
-      tags: true
+      branch: master
       repo: Yelp/synapse-tools

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
 all: itest_trusty
 
-itest_trusty: package_trusty
+itest_trusty: package_trusty bintray.json
 	rm -rf dockerfiles/itest/itest_trusty
 	cp -a dockerfiles/itest/itest dockerfiles/itest/itest_trusty
 	cp dockerfiles/itest/itest/Dockerfile.trusty dockerfiles/itest/itest_trusty/Dockerfile
 	tox -e itest_trusty
+
+DATE := $(shell date +'%Y-%m-%d')
+SYNAPSETOOLSVERSION := $(shell sed 's/.*(\(.*\)).*/\1/;q' src/debian/changelog)
+bintray.json: bintray.json.in src/debian/changelog
+	sed -e 's/@DATE@/$(DATE)/g' -e 's/@SYNAPSETOOLSVERSION@/$(SYNAPSETOOLSVERSION)/g' $< > $@
 
 package_trusty:
 	[ -d dist ] || mkdir dist

--- a/bintray.json.in
+++ b/bintray.json.in
@@ -1,0 +1,33 @@
+{
+    "package": {
+        "name": "synapse-tools",
+        "repo": "paasta",
+        "subject": "yelp",
+        "desc": "Tools for configuring synapse",
+        "website_url": "paasta.readthedocs.org",
+        "issue_tracker_url": "https://github.com/Yelp/synapse-tools/issues",
+        "vcs_url": "https://github.com/Yelp/synapse-tools.git",
+        "github_use_tag_release_notes": true,
+        "github_release_notes_file": "RELEASE.md",
+        "licenses": ["Apache-2.0"],
+        "labels": [],
+        "public_download_numbers": false,
+        "public_stats": false,
+        "attributes": []
+    },
+
+    "version": {
+        "name": "@SYNAPSETOOLSVERSION@",
+        "desc": "Version @SYNAPSETOOLSVERSION@",
+        "released": "@DATE@",
+        "vcs_tag": "v@SYNAPSETOOLSVERSION@",
+        "attributes": [],
+        "gpgSign": false
+    },
+
+    "files":
+        [
+        {"includePattern": "dist/(synapse-tools.*\.deb)", "uploadPattern": "$1", "matrixParams": { "deb_distribution": "trusty", "deb_component": "main", "deb_architecture": "amd64"} }
+        ],
+    "publish": true
+}


### PR DESCRIPTION
This branch builds itest_trusty with travis, and for tagged versions, pushes the built .deb to [Bintray](https://bintray.com/yelp/paasta/synapse-tools/view).

Similar to Yelp/paasta#337 

Fixes #5 