### PR TITLE
added backup backends to synapse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__
 *.pyc
+*.swp
 .pip/
 .tox/
 dist/

--- a/dockerfiles/itest/itest/Dockerfile.trusty
+++ b/dockerfiles/itest/itest/Dockerfile.trusty
@@ -24,7 +24,7 @@ RUN tar -axvf /haproxy.tar.gz
 WORKDIR /haproxy-1.6.0
 RUN make TARGET=linux26 && mv haproxy /usr/bin/haproxy-synapse
 
-RUN gem install --no-ri --no-rdoc synapse -v 0.12.1
+RUN gem install --no-ri --no-rdoc synapse -v 0.13.8
 
 ADD synapse.conf /etc/init/synapse.conf
 ADD synapse.conf.json /etc/synapse/synapse.conf.json

--- a/dockerfiles/itest/itest/itest.py
+++ b/dockerfiles/itest/itest/itest.py
@@ -27,7 +27,7 @@ SERVICES = {
         'mode': 'http',
         'healthcheck_uri': '/my_healthcheck_endpoint',
         'discover': 'habitat',
-        'advertise': ['habitat', 'advertise'],
+        'advertise': ['habitat', 'region'],
     },
 
     # TCP service

--- a/dockerfiles/itest/itest/itest.py
+++ b/dockerfiles/itest/itest/itest.py
@@ -96,7 +96,6 @@ def setup():
                 advertise_typ: 'my_%s' % advertise_typ
                 for advertise_typ in data['advertise']
             }
-            labels['remote'] = 'false'
             zk.create(
                 path=('/smartstack/global/%s/itesthost' % name),
                 value=(json.dumps({
@@ -178,11 +177,6 @@ def test_http_synapse_service_config(setup):
                     'value': 'my_habitat',
                     'condition': 'equals',
                 },
-                {
-                    'label': 'remote',
-                    'value': 'false',
-                    'condition': 'equals',
-                },
             ],
         },
         'haproxy': {
@@ -237,11 +231,6 @@ def test_backup_http_synapse_service_config(setup):
                     'value': 'my_region',
                     'condition': 'equals',
                 },
-                {
-                    'label': 'remote',
-                    'value': 'false',
-                    'condition': 'equals',
-                },
             ],
         },
         'haproxy': {
@@ -284,13 +273,8 @@ def test_remote_http_synapse_service_config(setup):
             'path': '/smartstack/global/service_three.main',
             'label_filters': [
                 {
-                    'label': 'remote_dst_loc',
+                    'label': 'remote_habitat',
                     'value': 'my_habitat',
-                    'condition': 'equals',
-                },
-                {
-                    'label': 'remote',
-                    'value': 'true',
                     'condition': 'equals',
                 },
             ],
@@ -337,11 +321,6 @@ def test_tcp_synapse_service_config(setup):
                 {
                     'label': 'region',
                     'value': 'my_region',
-                    'condition': 'equals',
-                },
-                {
-                    'label': 'remote',
-                    'value': 'false',
                     'condition': 'equals',
                 },
             ],

--- a/dockerfiles/itest/itest/itest.py
+++ b/dockerfiles/itest/itest/itest.py
@@ -92,16 +92,18 @@ def setup():
     try:
         # Fake out a nerve registration in Zookeeper for each service
         for name, data in SERVICES.iteritems():
+            labels = {
+                advertise_typ: 'my_%s' % advertise_typ
+                for advertise_typ in data['advertise']
+            }
+            labels['remote'] = 'false'
             zk.create(
                 path=('/smartstack/global/%s/itesthost' % name),
                 value=(json.dumps({
                     'host': data['ip_address'],
                     'port': data['port'],
                     'name': data['host'],
-                    'labels': {
-                        advertise_typ: 'my_%s' % advertise_typ
-                        for advertise_typ in data['advertise']
-                    },
+                    'labels': labels,
                 })),
                 ephemeral=True,
                 sequence=True,
@@ -176,6 +178,11 @@ def test_http_synapse_service_config(setup):
                     'value': 'my_habitat',
                     'condition': 'equals',
                 },
+                {
+                    'label': 'remote',
+                    'value': 'false',
+                    'condition': 'equals',
+                },
             ],
         },
         'haproxy': {
@@ -230,6 +237,11 @@ def test_backup_http_synapse_service_config(setup):
                     'value': 'my_region',
                     'condition': 'equals',
                 },
+                {
+                    'label': 'remote',
+                    'value': 'false',
+                    'condition': 'equals',
+                },
             ],
         },
         'haproxy': {
@@ -272,14 +284,14 @@ def test_remote_http_synapse_service_config(setup):
             'path': '/smartstack/global/service_three.main',
             'label_filters': [
                 {
-                    'label': 'habitat',
+                    'label': 'remote_dst_loc',
                     'value': 'my_habitat',
-                    'condition': 'not-equals',
+                    'condition': 'equals',
                 },
                 {
-                    'label': 'region',
-                    'value': 'my_region',
-                    'condition': 'not-equals',
+                    'label': 'remote',
+                    'value': 'true',
+                    'condition': 'equals',
                 },
             ],
         },
@@ -325,6 +337,11 @@ def test_tcp_synapse_service_config(setup):
                 {
                     'label': 'region',
                     'value': 'my_region',
+                    'condition': 'equals',
+                },
+                {
+                    'label': 'remote',
+                    'value': 'false',
                     'condition': 'equals',
                 },
             ],

--- a/dockerfiles/itest/itest/itest.py
+++ b/dockerfiles/itest/itest/itest.py
@@ -26,7 +26,8 @@ SERVICES = {
         'proxy_port': 20060,
         'mode': 'http',
         'healthcheck_uri': '/my_healthcheck_endpoint',
-        'discover': 'habitat'
+        'discover': 'habitat',
+        'advertise': ['habitat', 'advertise'],
     },
 
     # TCP service
@@ -36,7 +37,8 @@ SERVICES = {
         'port': 1025,
         'proxy_port': 20028,
         'mode': 'tcp',
-        'discover': 'region'
+        'discover': 'region',
+        'advertise': ['region'],
     },
 
     # HTTP service with a custom endpoint and chaos
@@ -48,7 +50,8 @@ SERVICES = {
         'mode': 'http',
         'healthcheck_uri': '/my_healthcheck_endpoint',
         'chaos': True,
-        'discover': 'region'
+        'discover': 'region',
+        'advertise': ['region'],
     },
 
     # HTTP with headers required for the healthcheck
@@ -59,11 +62,12 @@ SERVICES = {
         'proxy_port': 20090,
         'mode': 'http',
         'discover': 'habitat',
+        'advertise': ['habitat'],
         'healthcheck_uri': '/lil_brudder',
         'extra_healthcheck_headers': {
             'X-Mode': 'ro',
-        }
-    }
+        },
+    },
 }
 
 # How long Synapse gets to configure HAProxy on startup.  This value is
@@ -89,10 +93,16 @@ def setup():
         # Fake out a nerve registration in Zookeeper for each service
         for name, data in SERVICES.iteritems():
             zk.create(
-                path=('/nerve/%s:my_%s/%s/itesthost' %
-                      (data['discover'], data['discover'], name)),
-                value=('{"host": "%s", "port": %d, "name": "%s"}' %
-                       (data['ip_address'], data['port'], data['host'])),
+                path=('/nerve/all/%s/itesthost' % name),
+                value=(json.dumps({
+                    'host': data['ip_address'],
+                    'port': data['port'],
+                    'name': data['host'],
+                    'labels': {
+                        advertise_typ: 'my_%s' % advertise_typ
+                        for advertise_typ in data['advertise']
+                    },
+                })),
                 ephemeral=True,
                 sequence=True,
                 makepath=True,
@@ -133,7 +143,13 @@ def test_synapse_qdisc_tool(setup):
 
 
 def test_synapse_services(setup):
-    expected_services = ['service_three.main', 'service_one.main', 'service_three_chaos.main', 'service_two.main']
+    expected_services = [
+        'service_three.main',
+        'service_three.main.region',
+        'service_one.main',
+        'service_three_chaos.main',
+        'service_two.main',
+    ]
 
     with open('/etc/synapse/synapse.conf.json') as fd:
         synapse_config = json.load(fd)
@@ -149,7 +165,67 @@ def test_http_synapse_service_config(setup):
         'discovery': {
             'hosts': [ZOOKEEPER_CONNECT_STRING],
             'method': 'zookeeper',
-            'path': '/nerve/habitat:my_habitat/service_three.main'},
+            'path': '/nerve/all/service_three.main',
+            'label_filters': [
+                {
+                    'label': 'habitat',
+                    'value': 'my_habitat',
+                    'condition': 'equals',
+                },
+            ],
+        },
+        'haproxy': {
+            'listen': [
+                'option httpchk GET /http/service_three.main/0/my_healthcheck_endpoint',
+                'http-check send-state',
+                'retries 2',
+                'timeout connect 10000ms',
+                'timeout server 11000ms'
+            ],
+            'frontend': [
+                'timeout client 11000ms',
+                'capture request header X-B3-SpanId len 64',
+                'capture request header X-B3-TraceId len 64',
+                'capture request header X-B3-ParentSpanId len 64',
+                'capture request header X-B3-Flags len 10',
+                'capture request header X-B3-Sampled len 10',
+                'option httplog',
+                'acl service_three.main_has_connslots connslots(service_three.main) gt 0',
+                'use_backend service_three.main if service_three.main_has_connslots',
+                'acl service_three.main.region_has_connslots connslots(service_three.main.region) gt 0',
+                'use_backend service_three.main.region if service_three.main.region_has_connslots',
+                'default_backend service_three.main',
+            ],
+            'backend': [
+            ],
+            'port': '20060',
+            'server_options': 'check port 6666 observe layer7'
+        }
+    }
+
+    with open('/etc/synapse/synapse.conf.json') as fd:
+        synapse_config = json.load(fd)
+
+    actual_service_entry = synapse_config['services'].get('service_three.main')
+    assert expected_service_entry == actual_service_entry
+
+
+def test_backup_http_synapse_service_config(setup):
+    expected_service_entry = {
+        'default_servers': [],
+        'use_previous_backends': False,
+        'discovery': {
+            'hosts': [ZOOKEEPER_CONNECT_STRING],
+            'method': 'zookeeper',
+            'path': '/nerve/all/service_three.main',
+            'label_filters': [
+                {
+                    'label': 'region',
+                    'value': 'my_region',
+                    'condition': 'equals',
+                },
+            ],
+        },
         'haproxy': {
             'listen': [
                 'option httpchk GET /http/service_three.main/0/my_healthcheck_endpoint',
@@ -169,7 +245,6 @@ def test_http_synapse_service_config(setup):
             ],
             'backend': [
             ],
-            'port': '20060',
             'server_options': 'check port 6666 observe layer7'
         }
     }
@@ -177,7 +252,7 @@ def test_http_synapse_service_config(setup):
     with open('/etc/synapse/synapse.conf.json') as fd:
         synapse_config = json.load(fd)
 
-    actual_service_entry = synapse_config['services'].get('service_three.main')
+    actual_service_entry = synapse_config['services'].get('service_three.main.region')
     assert expected_service_entry == actual_service_entry
 
 
@@ -188,7 +263,15 @@ def test_tcp_synapse_service_config(setup):
         'discovery': {
             'hosts': [ZOOKEEPER_CONNECT_STRING],
             'method': 'zookeeper',
-            'path': '/nerve/region:my_region/service_one.main'},
+            'path': '/nerve/all/service_one.main',
+            'label_filters': [
+                {
+                    'label': 'region',
+                    'value': 'my_region',
+                    'condition': 'equals',
+                },
+            ],
+        },
         'haproxy': {
             'listen': [
                 'option httpchk GET /tcp/service_one.main/0/status',
@@ -250,7 +333,7 @@ def test_synapse_haproxy_stats_page(setup):
             if 'chaos' in data:
                 continue
 
-            svname = '%s:%d_%s' % (data['ip_address'], data['port'], data['host'])
+            svname = '%s_%s:%d' % (data['host'], data['ip_address'], data['port'])
             check_status = 'L7OK'
             assert (name, svname, check_status) in rows
 

--- a/dockerfiles/itest/itest/itest.py
+++ b/dockerfiles/itest/itest/itest.py
@@ -206,8 +206,9 @@ def test_http_synapse_service_config(setup):
             'backend': [
             ],
             'port': '20060',
-            'server_options': 'check port 6666 observe layer7'
-        }
+            'server_options': 'check port 6666 observe layer7 maxconn 50 maxqueue 10',
+            'backend_name': 'service_three.main',
+        },
     }
 
     with open('/etc/synapse/synapse.conf.json') as fd:
@@ -252,8 +253,9 @@ def test_backup_http_synapse_service_config(setup):
             ],
             'backend': [
             ],
-            'server_options': 'check port 6666 observe layer7'
-        }
+            'server_options': 'check port 6666 observe layer7 maxconn 50 maxqueue 10',
+            'backend_name': 'service_three.main.region',
+        },
     }
 
     with open('/etc/synapse/synapse.conf.json') as fd:
@@ -298,8 +300,9 @@ def test_remote_http_synapse_service_config(setup):
             ],
             'backend': [
             ],
-            'server_options': 'check port 6666 observe layer7'
-        }
+            'server_options': 'check port 6666 observe layer7 maxconn 50 maxqueue 10',
+            'backend_name': 'service_three.main.remote',
+        },
     }
 
     with open('/etc/synapse/synapse.conf.json') as fd:
@@ -345,8 +348,9 @@ def test_tcp_synapse_service_config(setup):
             'backend': [
             ],
             'port': '20028',
-            'server_options': 'check port 6666 observe layer4'
-        }
+            'server_options': 'check port 6666 observe layer4 maxconn 50 maxqueue 10',
+            'backend_name': 'service_one.main',
+        },
     }
 
     with open('/etc/synapse/synapse.conf.json') as fd:

--- a/dockerfiles/itest/itest/yelpsoa-configs/service_three/smartstack.yaml
+++ b/dockerfiles/itest/itest/yelpsoa-configs/service_three/smartstack.yaml
@@ -10,3 +10,6 @@ main:
   healthcheck_uri: /my_healthcheck_endpoint
   allredisp: False
   discover: habitat
+  advertise:
+  - habitat
+  - region

--- a/dockerfiles/itest/itest/yelpsoa-configs/service_two/smartstack.yaml
+++ b/dockerfiles/itest/itest/yelpsoa-configs/service_two/smartstack.yaml
@@ -7,6 +7,8 @@ main:
   healthcheck_uri: /lil_brudder
   allredisp: False
   discover: habitat
+  advertise:
+  - habitat
   extra_headers:
     X-Mode: ro
   extra_healthcheck_headers:

--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -257,6 +257,9 @@ def generate_configuration(synapse_tools_config, zookeeper_topology, services):
         # create the remote backend
         remote_config = copy.deepcopy(base_haproxy_cfg)
         remote_backend_name = '%s.remote' % service_name
+        # nerve handles extra_advertise by registering a remote server for
+        # every possible discover-level location. synapse then filters by the
+        # local location to find servers that are being extra_advertised to it
         remote_config['discovery']['label_filters'] = [
             {
                 'label': 'remote_%s' % discover_type,

--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -211,7 +211,8 @@ def generate_configuration(synapse_tools_config, zookeeper_topology, services):
     }
 
     for (service_name, service_info) in services:
-        if service_info.get('proxy_port') is None:
+        proxy_port = service_info.get('proxy_port')
+        if proxy_port is None:
             continue
 
         discover_type = service_info.get('discover', 'region')
@@ -223,7 +224,6 @@ def generate_configuration(synapse_tools_config, zookeeper_topology, services):
         if discover_type not in advertise_types:
             return {}
 
-        proxy_port = service_info['proxy_port']
 
         base_haproxy_cfg = base_haproxy_cfg_for_service(
             service_name=service_name,

--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -237,6 +237,11 @@ def generate_configuration(synapse_tools_config, zookeeper_topology, services):
                     'value': get_current_location(advertise_type),
                     'condition': 'equals',
                 },
+                {
+                    'label': 'remote',
+                    'value': 'false',
+                    'condition': 'equals',
+                },
             ]
 
             synapse_config['services'][backend_identifier] = config
@@ -245,11 +250,15 @@ def generate_configuration(synapse_tools_config, zookeeper_topology, services):
         remote_config = copy.deepcopy(base_haproxy_cfg)
         remote_config['discovery']['label_filters'] = [
             {
-                'label': advertise_type,
-                'value': get_current_location(advertise_type),
-                'condition': 'not-equals',
-            }
-            for advertise_type in advertise_types
+                'label': 'remote_dst_loc',
+                'value': get_current_location(discover_type),
+                'condition': 'equals',
+            },
+            {
+                'label': 'remote',
+                'value': 'true',
+                'condition': 'equals',
+            },
         ]
 
         synapse_config['services']['%s.remote' % service_name] = remote_config

--- a/src/synapse_tools/haproxy/qdisc_util.py
+++ b/src/synapse_tools/haproxy/qdisc_util.py
@@ -68,6 +68,7 @@ def needs_setup(interface_name):
         return 1
     return 0
 
+
 """
 Create a traffic control setup as follows
            1: root qdisc

--- a/src/tests/configure_synapse_test.py
+++ b/src/tests/configure_synapse_test.py
@@ -87,6 +87,11 @@ def test_generate_configuration(mock_get_current_location, mock_available_locati
                         'value': 'my_region',
                         'condition': 'equals',
                     },
+                    {
+                        'label': 'remote',
+                        'value': 'false',
+                        'condition': 'equals',
+                    },
                 ],
             },
             'haproxy': {
@@ -135,6 +140,11 @@ def test_generate_configuration(mock_get_current_location, mock_available_locati
                         'value': 'my_superregion',
                         'condition': 'equals',
                     },
+                    {
+                        'label': 'remote',
+                        'value': 'false',
+                        'condition': 'equals',
+                    },
                 ],
             },
             'haproxy': {
@@ -171,14 +181,14 @@ def test_generate_configuration(mock_get_current_location, mock_available_locati
                 'path': '/smartstack/global/test_service',
                 'label_filters': [
                     {
-                        'label': 'region',
+                        'label': 'remote_dst_loc',
                         'value': 'my_region',
-                        'condition': 'not-equals',
+                        'condition': 'equals',
                     },
                     {
-                        'label': 'superregion',
-                        'value': 'my_superregion',
-                        'condition': 'not-equals',
+                        'label': 'remote',
+                        'value': 'true',
+                        'condition': 'equals',
                     },
                 ],
             },


### PR DESCRIPTION
Added functionality to configure_synapse to create multiple backends for a service (one for each advertise type) and like them to one frontend using  haproxy ACLs.

@solarkennedy @jolynch @jnb 