### PR TITLE
Have haproxy-synapse expose unix sockets for each service

### DIFF
--- a/dockerfiles/itest/itest/itest.py
+++ b/dockerfiles/itest/itest/itest.py
@@ -184,6 +184,7 @@ def test_http_synapse_service_config(setup):
                 'timeout server 11000ms'
             ],
             'frontend': [
+                'bind /var/run/synapse/sockets/service_three.main.sock',
                 'timeout client 11000ms',
                 'capture request header X-B3-SpanId len 64',
                 'capture request header X-B3-TraceId len 64',
@@ -236,6 +237,7 @@ def test_backup_http_synapse_service_config(setup):
                 'timeout server 11000ms'
             ],
             'frontend': [
+                'bind /var/run/synapse/sockets/service_three.main.sock',
                 'timeout client 11000ms',
                 'capture request header X-B3-SpanId len 64',
                 'capture request header X-B3-TraceId len 64',
@@ -283,6 +285,7 @@ def test_tcp_synapse_service_config(setup):
                 'timeout server 11000ms'
             ],
             'frontend': [
+                'bind /var/run/synapse/sockets/service_one.main.sock',
                 'timeout client 12000ms',
                 'option tcplog',
                 'acl service_one.main_has_connslots connslots(service_one.main) gt 0',

--- a/dockerfiles/itest/itest/itest.py
+++ b/dockerfiles/itest/itest/itest.py
@@ -131,6 +131,14 @@ def setup():
         zk.stop()
 
 
+def _sort_lists_in_dict(d):
+    for k in d:
+        if isinstance(d[k], dict):
+            d[k] = _sort_lists_in_dict(d[k])
+        elif isinstance(d[k], list):
+            d[k] = sorted(d[k])
+    return d
+
 def test_haproxy_synapse_reaper(setup):
     # This should run with no errors.  Everything is running as root, so we need
     # to use the --username option here.
@@ -209,6 +217,10 @@ def test_http_synapse_service_config(setup):
         synapse_config = json.load(fd)
 
     actual_service_entry = synapse_config['services'].get('service_three.main')
+
+    actual_service_entry = _sort_lists_in_dict(actual_service_entry)
+    expected_service_entry = _sort_lists_in_dict(expected_service_entry)
+
     assert expected_service_entry == actual_service_entry
 
 
@@ -237,14 +249,14 @@ def test_backup_http_synapse_service_config(setup):
                 'timeout server 11000ms'
             ],
             'frontend': [
+                'option httplog',
                 'timeout client 11000ms',
-                'bind /var/run/synapse/sockets/service_three.main.sock',
                 'capture request header X-B3-SpanId len 64',
+                'bind /var/run/synapse/sockets/service_three.main.sock',
                 'capture request header X-B3-TraceId len 64',
-                'capture request header X-B3-ParentSpanId len 64',
                 'capture request header X-B3-Flags len 10',
                 'capture request header X-B3-Sampled len 10',
-                'option httplog',
+                'capture request header X-B3-ParentSpanId len 64',
             ],
             'backend': [
             ],
@@ -257,6 +269,10 @@ def test_backup_http_synapse_service_config(setup):
         synapse_config = json.load(fd)
 
     actual_service_entry = synapse_config['services'].get('service_three.main.region')
+
+    actual_service_entry = _sort_lists_in_dict(actual_service_entry)
+    expected_service_entry = _sort_lists_in_dict(expected_service_entry)
+
     assert expected_service_entry == actual_service_entry
 
 
@@ -302,6 +318,9 @@ def test_tcp_synapse_service_config(setup):
     with open('/etc/synapse/synapse.conf.json') as fd:
         synapse_config = json.load(fd)
     actual_service_entry = synapse_config['services'].get('service_one.main')
+
+    actual_service_entry = _sort_lists_in_dict(actual_service_entry)
+    expected_service_entry = _sort_lists_in_dict(expected_service_entry)
 
     assert expected_service_entry == actual_service_entry
 

--- a/dockerfiles/itest/itest/itest.py
+++ b/dockerfiles/itest/itest/itest.py
@@ -184,8 +184,8 @@ def test_http_synapse_service_config(setup):
                 'timeout server 11000ms'
             ],
             'frontend': [
-                'bind /var/run/synapse/sockets/service_three.main.sock',
                 'timeout client 11000ms',
+                'bind /var/run/synapse/sockets/service_three.main.sock',
                 'capture request header X-B3-SpanId len 64',
                 'capture request header X-B3-TraceId len 64',
                 'capture request header X-B3-ParentSpanId len 64',
@@ -237,8 +237,8 @@ def test_backup_http_synapse_service_config(setup):
                 'timeout server 11000ms'
             ],
             'frontend': [
-                'bind /var/run/synapse/sockets/service_three.main.sock',
                 'timeout client 11000ms',
+                'bind /var/run/synapse/sockets/service_three.main.sock',
                 'capture request header X-B3-SpanId len 64',
                 'capture request header X-B3-TraceId len 64',
                 'capture request header X-B3-ParentSpanId len 64',
@@ -285,8 +285,8 @@ def test_tcp_synapse_service_config(setup):
                 'timeout server 11000ms'
             ],
             'frontend': [
-                'bind /var/run/synapse/sockets/service_one.main.sock',
                 'timeout client 12000ms',
+                'bind /var/run/synapse/sockets/service_one.main.sock',
                 'option tcplog',
                 'acl service_one.main_has_connslots connslots(service_one.main) gt 0',
                 'use_backend service_one.main if service_one.main_has_connslots',

--- a/dockerfiles/itest/itest/run_itest.sh
+++ b/dockerfiles/itest/itest/run_itest.sh
@@ -11,5 +11,8 @@ apt-get -y install -f
 echo "Testing that pyyaml uses optimized cyaml parsers if present"
 /usr/share/python/synapse-tools/bin/python -c 'import yaml; assert yaml.__with_libyaml__'
 
+echo "Creating directory for unix sockets"
+mkdir -p /var/run/synapse/sockets
+
 echo "Full integration test"
 py.test /itest.py

--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -290,6 +290,8 @@ def base_haproxy_cfg_for_service(service_name, service_info, zookeeper_topology,
     if timeout_client_ms is not None:
         frontend_options.append('timeout client %dms' % timeout_client_ms)
 
+    frontend_options.append('bind /var/run/synapse/sockets/%s.sock' % service_name)
+
     if mode == 'http':
         frontend_options.append('capture request header X-B3-SpanId len 64')
         frontend_options.append('capture request header X-B3-TraceId len 64')

--- a/src/tests/configure_synapse_test.py
+++ b/src/tests/configure_synapse_test.py
@@ -133,6 +133,7 @@ def test_generate_configuration(mock_get_current_location, mock_available_locati
                 ],
                 'frontend': [
                     'timeout client 3000ms',
+                    'bind /var/run/synapse/sockets/test_service.sock',
                     'capture request header X-B3-SpanId len 64',
                     'capture request header X-B3-TraceId len 64',
                     'capture request header X-B3-ParentSpanId len 64',
@@ -179,6 +180,7 @@ def test_generate_configuration(mock_get_current_location, mock_available_locati
                 ],
                 'frontend': [
                     'timeout client 3000ms',
+                    'bind /var/run/synapse/sockets/test_service.sock',
                     'capture request header X-B3-SpanId len 64',
                     'capture request header X-B3-TraceId len 64',
                     'capture request header X-B3-ParentSpanId len 64',
@@ -281,6 +283,7 @@ def test_generate_configuration_single_advertise(mock_get_current_location, mock
                 ],
                 'frontend': [
                     'timeout client 3000ms',
+                    'bind /var/run/synapse/sockets/test_service.sock',
                     'capture request header X-B3-SpanId len 64',
                     'capture request header X-B3-TraceId len 64',
                     'capture request header X-B3-ParentSpanId len 64',


### PR DESCRIPTION
Done in `configure_synapse.py` by injecting a new `bind /var/run/synapse/sockets/%s.sock` line into haproxy.conf.json, to be read by synapse in setting up its haproxy instance.

The tests were updated to reflect this new entry in the 'frontend' section of the generated json. A small helper function was added in the itest to sort lists nested inside dicts. When testing this, I didn't craft the mock json in the same way it was being generated, causing failures due to the differences in list orderings.

Installing this new synapse-tools package will cause /var/run/synapse/sockets/ to be populated with a unix socket for each service, as long as that directory is already created (we'll have to do this in puppet).

Using our internal `proxycurl` based on a recent version of curl, testing these sockets with `sudo proxycurl --unix-socket /var/run/synapse/sockets/devops.demo.sock http://localhost/status` returns the status json, just like curl'ing the TCP/IP endpoint.