### PR TITLE
Adding errorfiles options

### DIFF
--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -159,6 +159,31 @@ def generate_base_config(synapse_tools_config):
             }
         }
     }
+
+    # This allows us to add optional non-default error file directives; they
+    # should be a nested JSON object within the synapse-tools config of this
+    # sort:
+    # {
+    #   'errorfiles': {
+    #     '404': '/etc/haproxy-synapse/errors/404.http',
+    #     '503': '/etc/haproxy-synapse/errors/503.http'
+    #   }
+    # }
+    #
+    # This will add the following lines to the 'defaults' section of the
+    # haproxy config:
+    # errorfile 404 /etc/haproxy-synapse/errors/404.http
+    # errorfile 503 /etc/haproxy-synapse/errors/503.http
+    if synapse_tools_config['errorfiles']:
+        error_list = []
+        for error in synapse_tools_config['errorfiles']:
+            new_error = 'errorfile ' + error + ' ' + synapse_tools_config['errorfiles'][error]
+            error_list.append(new_error)
+
+
+        base_config['defaults'].extend(new_error)
+
+
     return base_config
 
 

--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -174,13 +174,11 @@ def generate_base_config(synapse_tools_config):
     # haproxy config:
     # errorfile 404 /etc/haproxy-synapse/errors/404.http
     # errorfile 503 /etc/haproxy-synapse/errors/503.http
-    if synapse_tools_config.get('errorfiles', False):
-        error_list = []
-        for error, errorfile in synapse_tools_config['errorfiles'].iteritems():
-            new_error = 'errorfile ' + error + ' ' + errorfile
-            error_list.append(new_error)
-
-        base_config['haproxy']['defaults'].extend(error_list)
+    error_list = [
+        "errorfile {} {}".format(error, errorfile)
+        for error, errorfile in synapse_tools_config.get('errorfiles', {}).iteritems()
+    ]
+    base_config['haproxy']['defaults'].extend(error_list)
 
     return base_config
 

--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -174,15 +174,13 @@ def generate_base_config(synapse_tools_config):
     # haproxy config:
     # errorfile 404 /etc/haproxy-synapse/errors/404.http
     # errorfile 503 /etc/haproxy-synapse/errors/503.http
-    if synapse_tools_config['errorfiles']:
+    if synapse_tools_config.get('errorfiles', False):
         error_list = []
-        for error in synapse_tools_config['errorfiles']:
-            new_error = 'errorfile ' + error + ' ' + synapse_tools_config['errorfiles'][error]
+        for error, errorfile in synapse_tools_config['errorfiles'].iteritems():
+            new_error = 'errorfile ' + error + ' ' + errorfile
             error_list.append(new_error)
 
-
-        base_config['defaults'].extend(new_error)
-
+        base_config['haproxy']['defaults'].extend(error_list)
 
     return base_config
 


### PR DESCRIPTION
This change adds the ability to specify different default errorfiles in the haproxy-synapse config; it should be entirely optional.