### PR TITLE
Support NGINX Listening

### DIFF
--- a/dockerfiles/itest/itest/Dockerfile.lucid
+++ b/dockerfiles/itest/itest/Dockerfile.lucid
@@ -13,11 +13,14 @@ RUN apt-get update && apt-get -y install \
     rbenv \
     rbenv-ruby-1.9.3-p448 \
     python2.7 \
-    synapse
+    synapse \
+    nginx
 
 ADD synapse.conf /etc/init/synapse.conf
 ADD synapse.conf.json /etc/synapse/synapse.conf.json
 ADD synapse-tools.conf.json /etc/synapse/synapse-tools.conf.json
+ADD synapse-tools-both.conf.json /etc/synapse/synapse-tools-both.conf.json
+ADD synapse-tools-nginx.conf.json /etc/synapse/synapse-tools-nginx.conf.json
 ADD yelpsoa-configs /nail/etc/services
 ADD zookeeper_discovery /nail/etc/zookeeper_discovery
 ADD habitat /nail/etc/habitat

--- a/dockerfiles/itest/itest/Dockerfile.trusty
+++ b/dockerfiles/itest/itest/Dockerfile.trusty
@@ -17,7 +17,8 @@ RUN apt-get update && apt-get -y install \
     libxml2-dev \
     libxslt-dev \
     build-essential \
-    zlib1g-dev
+    zlib1g-dev \
+    nginx
 
 ADD https://github.com/haproxy/haproxy/archive/v1.6.0.tar.gz /haproxy.tar.gz
 RUN tar -axvf /haproxy.tar.gz
@@ -26,11 +27,15 @@ RUN make TARGET=linux26 && mv haproxy /usr/bin/haproxy-synapse
 
 # Pin for test reproducibility
 RUN gem install --no-ri --no-rdoc nokogiri -v 1.6.7.2
-RUN gem install --no-ri --no-rdoc synapse -v 0.13.8
+RUN gem install --no-ri --no-rdoc synapse -v 0.14.1
+RUN gem install --no-ri --no-rdoc synapse-nginx -v 0.2.0
 
 ADD synapse.conf /etc/init/synapse.conf
 ADD synapse.conf.json /etc/synapse/synapse.conf.json
 ADD synapse-tools.conf.json /etc/synapse/synapse-tools.conf.json
+ADD synapse-tools-both.conf.json /etc/synapse/synapse-tools-both.conf.json
+ADD synapse-tools-nginx.conf.json /etc/synapse/synapse-tools-nginx.conf.json
+
 ADD yelpsoa-configs /nail/etc/services
 ADD zookeeper_discovery /nail/etc/zookeeper_discovery
 ADD habitat /nail/etc/habitat

--- a/dockerfiles/itest/itest/Dockerfile.trusty
+++ b/dockerfiles/itest/itest/Dockerfile.trusty
@@ -16,19 +16,44 @@ RUN apt-get update && apt-get -y install \
     libxml2 \
     libxml2-dev \
     libxslt-dev \
+    libssl-dev \
     build-essential \
-    zlib1g-dev \
-    nginx
+    zlib1g-dev
 
+# Ubuntu trusty nginx and haproxy are ancient, grab newer ones
 ADD https://github.com/haproxy/haproxy/archive/v1.6.0.tar.gz /haproxy.tar.gz
 RUN tar -axvf /haproxy.tar.gz
 WORKDIR /haproxy-1.6.0
-RUN make TARGET=linux26 && mv haproxy /usr/bin/haproxy-synapse
+RUN pwd
+RUN make TARGET=linux26 -j 4 && mv haproxy /usr/bin/haproxy-synapse
+
+WORKDIR /
+ADD https://nginx.org/download/nginx-1.11.10.tar.gz /nginx.tar.gz
+RUN tar -axvf /nginx.tar.gz
+WORKDIR /nginx-1.11.10
+RUN ./configure \
+    --prefix=/etc/nginx \
+    --sbin-path=/usr/sbin/nginx \
+    --conf-path=/etc/nginx/nginx.conf \
+    --error-log-path=/var/log/nginx/error.log \
+    --http-log-path=/var/log/nginx/access.log \
+    --pid-path=/var/run/nginx.pid \
+    --lock-path=/var/run/nginx.lock \
+    --user=nginx \
+    --group=nginx \
+    --with-http_ssl_module \
+    --with-stream \
+    --without-http_rewrite_module \
+    --without-http_gzip_module
+
+
+RUN make -j 4
+RUN make install
 
 # Pin for test reproducibility
 RUN gem install --no-ri --no-rdoc nokogiri -v 1.6.7.2
 RUN gem install --no-ri --no-rdoc synapse -v 0.14.1
-RUN gem install --no-ri --no-rdoc synapse-nginx -v 0.2.0
+RUN gem install --no-ri --no-rdoc synapse-nginx -v 0.2.2
 
 ADD synapse.conf /etc/init/synapse.conf
 ADD synapse.conf.json /etc/synapse/synapse.conf.json

--- a/dockerfiles/itest/itest/Dockerfile.xenial
+++ b/dockerfiles/itest/itest/Dockerfile.xenial
@@ -16,7 +16,8 @@ RUN apt-get update && apt-get -y install \
     libxml2-dev \
     libxslt-dev \
     build-essential \
-    zlib1g-dev
+    zlib1g-dev \
+    nginx
 
 ADD https://github.com/haproxy/haproxy/archive/v1.6.0.tar.gz /haproxy.tar.gz
 RUN tar -axvf /haproxy.tar.gz
@@ -25,11 +26,15 @@ RUN make TARGET=linux26 && mv haproxy /usr/bin/haproxy-synapse
 
 # Pin for test reproducibility
 RUN gem install --no-ri --no-rdoc nokogiri -v 1.6.7.2
-RUN gem install --no-ri --no-rdoc synapse -v 0.13.8
+RUN gem install --no-ri --no-rdoc synapse -v 0.14.1
+RUN gem install --no-ri --no-rdoc synapse-nginx -v 0.2.0
 
 ADD synapse.conf /etc/init/synapse.conf
 ADD synapse.conf.json /etc/synapse/synapse.conf.json
 ADD synapse-tools.conf.json /etc/synapse/synapse-tools.conf.json
+ADD synapse-tools-both.conf.json /etc/synapse/synapse-tools-both.conf.json
+ADD synapse-tools-nginx.conf.json /etc/synapse/synapse-tools-nginx.conf.json
+
 ADD yelpsoa-configs /nail/etc/services
 ADD zookeeper_discovery /nail/etc/zookeeper_discovery
 ADD habitat /nail/etc/habitat

--- a/dockerfiles/itest/itest/Dockerfile.xenial
+++ b/dockerfiles/itest/itest/Dockerfile.xenial
@@ -27,7 +27,7 @@ RUN make TARGET=linux26 && mv haproxy /usr/bin/haproxy-synapse
 # Pin for test reproducibility
 RUN gem install --no-ri --no-rdoc nokogiri -v 1.6.7.2
 RUN gem install --no-ri --no-rdoc synapse -v 0.14.1
-RUN gem install --no-ri --no-rdoc synapse-nginx -v 0.2.0
+RUN gem install --no-ri --no-rdoc synapse-nginx -v 0.2.2
 
 ADD synapse.conf /etc/init/synapse.conf
 ADD synapse.conf.json /etc/synapse/synapse.conf.json

--- a/dockerfiles/itest/itest/itest.py
+++ b/dockerfiles/itest/itest/itest.py
@@ -125,9 +125,9 @@ def setup(request):
         # Run it to generate a new synapse configuration file.
         subprocess.check_call(
             ['configure_synapse'],
-            env={
-                'SYNAPSE_TOOLS_CONFIG_PATH': request.param
-            }
+            env=dict(
+                os.environ, SYNAPSE_TOOLS_CONFIG_PATH=request.param
+            )
         )
 
         # Normally configure_synapse would start up synapse using 'service synapse start'.

--- a/dockerfiles/itest/itest/itest.py
+++ b/dockerfiles/itest/itest/itest.py
@@ -185,7 +185,8 @@ def test_synapse_services(setup):
         synapse_config = json.load(fd)
     actual_services = synapse_config['services'].keys()
 
-    # nginx adds listener "services" which are noops
+    # nginx adds listener "services" which contain the proxy
+    # back to HAProxy sockets which actually do the load balancing
     if setup in SYNAPSE_TOOLS_CONFIGURATIONS['nginx']:
         nginx_services = [
             'service_three_chaos.main.nginx_listener',
@@ -221,11 +222,14 @@ def test_http_synapse_service_config(setup):
 
     actual_service_entry = synapse_config['services'].get('service_three.main')
 
-    # Unit tests test the haproxy and nginx sections, itests just need
-    # to make sure it like ... exists
-    actual_haproxy_section = actual_service_entry['haproxy']
+    # Unit tests already test the contents of the haproxy and nginx sections
+    # itests operate at a higher level of abstraction and need not care about
+    # how exactly SmartStack achieves the goal of load balancing
+    # So, we just check that the sections are there, but not what's in them!
+    assert 'haproxy' in actual_service_entry
     del actual_service_entry['haproxy']
-    if 'nginx' in actual_service_entry:
+    if setup in SYNAPSE_TOOLS_CONFIGURATIONS['nginx']:
+        assert 'nginx' in actual_service_entry
         del actual_service_entry['nginx']
 
     actual_service_entry = _sort_lists_in_dict(actual_service_entry)
@@ -257,11 +261,14 @@ def test_backup_http_synapse_service_config(setup):
 
     actual_service_entry = synapse_config['services'].get('service_three.main.region')
 
-    # Unit tests test the haproxy and nginx sections, itests just need
-    # to make sure it like ... exists
-    actual_haproxy_section = actual_service_entry['haproxy']
+    # Unit tests already test the contents of the haproxy and nginx sections
+    # itests operate at a higher level of abstraction and need not care about
+    # how exactly SmartStack achieves the goal of load balancing
+    # So, we just check that the sections are there, but not what's in them!
+    assert 'haproxy' in actual_service_entry
     del actual_service_entry['haproxy']
-    if 'nginx' in actual_service_entry:
+    if setup in SYNAPSE_TOOLS_CONFIGURATIONS['nginx']:
+        assert 'nginx' in actual_service_entry
         del actual_service_entry['nginx']
 
     actual_service_entry = _sort_lists_in_dict(actual_service_entry)
@@ -292,11 +299,14 @@ def test_tcp_synapse_service_config(setup):
         synapse_config = json.load(fd)
     actual_service_entry = synapse_config['services'].get('service_one.main')
 
-    # Unit tests test the haproxy and nginx sections, itests just need
-    # to make sure it like ... exists
-    actual_haproxy_section = actual_service_entry['haproxy']
+    # Unit tests already test the contents of the haproxy and nginx sections
+    # itests operate at a higher level of abstraction and need not care about
+    # how exactly SmartStack achieves the goal of load balancing
+    # So, we just check that the sections are there, but not what's in them!
+    assert 'haproxy' in actual_service_entry
     del actual_service_entry['haproxy']
-    if 'nginx' in actual_service_entry:
+    if setup in SYNAPSE_TOOLS_CONFIGURATIONS['nginx']:
+        assert 'nginx' in actual_service_entry
         del actual_service_entry['nginx']
 
     actual_service_entry = _sort_lists_in_dict(actual_service_entry)

--- a/dockerfiles/itest/itest/synapse-tools-both.conf.json
+++ b/dockerfiles/itest/itest/synapse-tools-both.conf.json
@@ -1,0 +1,8 @@
+{
+  "config_file": "/etc/synapse/synapse.conf.json",
+  "bind_addr": "0.0.0.0",
+  "stats_port": 32123,
+  "haproxy.defaults.inter": "10s",
+  "listen_with_nginx": true,
+  "listen_with_haproxy": true
+}

--- a/dockerfiles/itest/itest/synapse-tools-nginx.conf.json
+++ b/dockerfiles/itest/itest/synapse-tools-nginx.conf.json
@@ -1,0 +1,8 @@
+{
+  "config_file": "/etc/synapse/synapse.conf.json",
+  "bind_addr": "0.0.0.0",
+  "stats_port": 32123,
+  "haproxy.defaults.inter": "10s",
+  "listen_with_haproxy": false,
+  "listen_with_nginx": true
+}

--- a/dockerfiles/trusty/Dockerfile
+++ b/dockerfiles/trusty/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get -y install \
     libssl-dev \
     build-essential \
     gdebi-core \
+    wget \
     protobuf-compiler
 
 RUN cd /tmp && \

--- a/dockerfiles/trusty/Dockerfile
+++ b/dockerfiles/trusty/Dockerfile
@@ -18,7 +18,12 @@ RUN apt-get update && apt-get -y install \
     libffi-dev \
     libssl-dev \
     build-essential \
-    dh-virtualenv \
+    gdebi-core \
     protobuf-compiler
+
+RUN cd /tmp && \
+    wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.0-1_all.deb && \
+    gdebi -n dh-virtualenv*.deb && \
+    rm dh-virtualenv_*.deb
 
 WORKDIR /work

--- a/dockerfiles/xenial/Dockerfile
+++ b/dockerfiles/xenial/Dockerfile
@@ -12,7 +12,13 @@ RUN apt-get update && apt-get -y install \
     libffi-dev \
     libssl-dev \
     build-essential \
-    dh-virtualenv \
-    protobuf-compiler
+    protobuf-compiler \
+    gdebi-core \
+    wget
+
+RUN cd /tmp && \
+    wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.0-1_all.deb && \
+    gdebi -n dh-virtualenv*.deb && \
+    rm dh-virtualenv_*.deb
 
 WORKDIR /work

--- a/src/debian/changelog
+++ b/src/debian/changelog
@@ -1,3 +1,9 @@
+synapse-tools (0.12.0) lucid; urgency=low
+
+  * Adding support for nginx listeners
+
+ -- Joseph Lynch <jlynch@yelp.com>  Fri, 17 Mar 2017 22:30:33 -0700
+
 synapse-tools (0.11.7) lucid; urgency=low
 
   * Adds custom errorfiles capability

--- a/src/debian/rules
+++ b/src/debian/rules
@@ -5,15 +5,6 @@ export DH_VIRTUALENV_INSTALL_ROOT=/opt/venvs
 
 export DH_OPTIONS
 
-LSBDISTRELEASE := $(shell lsb_release -sr)
-
-# https://github.com/spotify/dh-virtualenv/issues/150
-ifneq ($(LSBDISTRELEASE),10.04)
-  pip_args=--extra-pip-arg='--no-use-wheel'
-else
-  pip_args=
-endif
-
 %:
 	dh $@ --with python-virtualenv
 
@@ -29,4 +20,6 @@ override_dh_auto_test:
 	true
 
 override_dh_virtualenv:
-	dh_virtualenv --python=/usr/bin/python2.7 $(pip_args)
+	dh_virtualenv `host pypi.yelpcorp.com >/dev/null 2>&1 && echo '--extra-index-url https://pypi.yelpcorp.com/simple'` \
+	--python=/usr/bin/python2.7 --preinstall no-manylinux1 \
+	--preinstall pip-custom-platform --pip-tool pip-custom-platform

--- a/src/setup.py
+++ b/src/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='synapse-tools',
-    version='0.11.7',
+    version='0.12.0',
     provides=['synapse_tools'],
     author='John Billings',
     author_email='billings@yelp.com',

--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -91,9 +91,6 @@ def _generate_nginx_top_level(synapse_tools_config):
             'http': [
                 'access_log off',
             ],
-            'stream': [
-                'access_log off',
-            ],
             'events': [
                 'worker_connections {0}'.format(
                     synapse_tools_config['maximum_connections']

--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -407,9 +407,11 @@ def generate_configuration(synapse_tools_config, zookeeper_topology, services):
                         config['haproxy']['frontend'].append(
                             'bind {0}'.format(socket_path)
                         )
-                    # If listen_with_haproxy is False, and we're only listening
-                    # with nginx, then have the haproxy bind only to the socket
-                    elif synapse_tools_config['listen_with_nginx']:
+                    # If listen_with_haproxy is False, then have
+                    # HAProxy bind only to the socket. Nginx may or may not
+                    # be listening on ports based on listen_with_nginx values
+                    # at this stage.
+                    else:
                         config['haproxy']['port'] = None
                         config['haproxy']['bind_address'] = _get_socket_path(
                             synapse_tools_config, service_name

--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -62,6 +62,7 @@ def set_defaults(config):
             '{nginx_path} -c {nginx_config_path}'),
         ('nginx_check_cmd_fmt',
             '{nginx_path} -t -c {nginx_config_path}'),
+        ('nginx_user_group', 'nobody nogroup'),
     ]
 
     for k, v in defaults:
@@ -84,6 +85,14 @@ def _generate_nginx_top_level(synapse_tools_config):
             'main': [
                 'worker_processes 1',
                 'pid {0}'.format(synapse_tools_config['nginx_pid_file_path']),
+                'user {0}'.format(synapse_tools_config['nginx_user_group']),
+                'error_log /dev/null crit',
+            ],
+            'http': [
+                'access_log off',
+            ],
+            'stream': [
+                'access_log off',
             ],
             'events': [
                 'worker_connections {0}'.format(

--- a/src/tests/configure_synapse_test.py
+++ b/src/tests/configure_synapse_test.py
@@ -599,7 +599,7 @@ def test_generate_configuration_with_nginx(mock_get_current_location, mock_avail
             'nginx': {
                 'mode': 'http',
                 'port': 1234,
-                'server_option': [
+                'server': [
                     'proxy_send_timeout 3010ms',
                     'proxy_read_timeout 3010ms'
                 ],
@@ -743,7 +743,7 @@ def test_generate_configuration_only_nginx(mock_get_current_location, mock_avail
             'nginx': {
                 'mode': 'http',
                 'port': 1234,
-                'server_option': [
+                'server': [
                     'proxy_send_timeout 3010ms',
                     'proxy_read_timeout 3010ms'
                 ]


### PR DESCRIPTION
This depends on [synapse-nginx](https://github.com/jolynch/synapse-nginx) 0.2.2, and allows us to start switching over Smartstack listeners from HAProxy to nginx.

The main contribution here is that we can do the rollout gradually by controlling the "listen_with_X" configuration flags, where we can have just HAProxy bind the listen ports, both HAProxy and nginx bind the listen ports, and just NGINX bind the listen ports.

The integration tests are expanded to test all three listening setups. Integration tests that were better suited for unit tests (testing exact implementation details) were refactored since unit tests cover config generation.

I think I still need to figure out how to make nginx act as a fully transparent proxy (right now it sends back the wrong headers I think), and I need to iron out user/group issues. I'd like to get the review started since it's so significant though.

@jnb @solarkennedy @EvanKrall heads up :-)