### PR TITLE
Fixes for nginx listeners

### DIFF
--- a/dockerfiles/itest/itest/Dockerfile.trusty
+++ b/dockerfiles/itest/itest/Dockerfile.trusty
@@ -39,8 +39,8 @@ RUN ./configure \
     --http-log-path=/var/log/nginx/access.log \
     --pid-path=/var/run/nginx.pid \
     --lock-path=/var/run/nginx.lock \
-    --user=nginx \
-    --group=nginx \
+    --user=nobody \
+    --group=nogroup \
     --with-http_ssl_module \
     --with-stream \
     --without-http_rewrite_module \

--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -533,6 +533,7 @@ def _generate_haproxy_for_watcher(service_name, service_info, synapse_tools_conf
         frontend_options.append('capture request header X-B3-Sampled len 10')
         frontend_options.append('option httplog')
     elif mode == 'tcp':
+        frontend_options.append('no option accept-invalid-http-request')
         frontend_options.append('option tcplog')
 
     # backend options

--- a/src/tests/configure_synapse_test.py
+++ b/src/tests/configure_synapse_test.py
@@ -600,8 +600,8 @@ def test_generate_configuration_with_nginx(mock_get_current_location, mock_avail
                 'mode': 'http',
                 'port': 1234,
                 'server': [
-                    'proxy_send_timeout 3010ms',
-                    'proxy_read_timeout 3010ms'
+                    'proxy_send_timeout 3600s',
+                    'proxy_read_timeout 3600s'
                 ],
                 'listen_options': 'reuseport',
             },
@@ -744,8 +744,8 @@ def test_generate_configuration_only_nginx(mock_get_current_location, mock_avail
                 'mode': 'http',
                 'port': 1234,
                 'server': [
-                    'proxy_send_timeout 3010ms',
-                    'proxy_read_timeout 3010ms'
+                    'proxy_send_timeout 3600s',
+                    'proxy_read_timeout 3600s'
                 ]
             },
             'use_previous_backends': True

--- a/src/tests/configure_synapse_test.py
+++ b/src/tests/configure_synapse_test.py
@@ -600,8 +600,8 @@ def test_generate_configuration_with_nginx(mock_get_current_location, mock_avail
                 'mode': 'http',
                 'port': 1234,
                 'server': [
-                    'proxy_send_timeout 3600s',
-                    'proxy_read_timeout 3600s'
+                    'proxy_send_timeout 3610s',
+                    'proxy_read_timeout 3610s'
                 ],
                 'listen_options': 'reuseport',
             },
@@ -744,8 +744,8 @@ def test_generate_configuration_only_nginx(mock_get_current_location, mock_avail
                 'mode': 'http',
                 'port': 1234,
                 'server': [
-                    'proxy_send_timeout 3600s',
-                    'proxy_read_timeout 3600s'
+                    'proxy_send_timeout 3610s',
+                    'proxy_read_timeout 3610s'
                 ]
             },
             'use_previous_backends': True


### PR DESCRIPTION
This addresses the issues with nginx listeners. Specifically:

- Got rid of user directive since we're not launching as root
- Made reloads use the "graceful reload" strategy instead of just HUP. This way new binaries will automatically be picked up
- Cleaned up timeouts to just be the same high value for all listeners (60 minutes since that's or max SS timeout). This means that the only thing we will restart nginx for is new services (this happens basically never)
- Rate limit nginx restarts to once every 10 minutes (since new services rarely happen)
- Try to make the headers less wonky (unfortunately no way to kill Date or Server, but we can at least pass backing Servers forward).