### PR TITLE
Disable file output on sockets

### DIFF
--- a/src/debian/changelog
+++ b/src/debian/changelog
@@ -1,3 +1,9 @@
+synapse-tools (0.12.3) lucid; urgency=low
+
+  * Disable the file output for nginx listeners
+
+ -- Joseph Lynch <jlynch@yelp.com>  Thu, 13 Apr 2017 13:42:04 -0700
+
 synapse-tools (0.12.2) lucid; urgency=low
 
   * Reload command formatting bug

--- a/src/setup.py
+++ b/src/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='synapse-tools',
-    version='0.12.2',
+    version='0.12.3',
     provides=['synapse_tools'],
     author='John Billings',
     author_email='billings@yelp.com',

--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -653,7 +653,6 @@ def _generate_nginx_for_watcher(service_name, service_info, synapse_tools_config
         nginx_config['listen_options'] = 'reuseport'
 
     service = {
-        # The "None" port informs SmartStack this service has no port
         'default_servers': [
             {'host': 'unix', 'port': socket_path}
         ],
@@ -662,6 +661,9 @@ def _generate_nginx_for_watcher(service_name, service_info, synapse_tools_config
             'method': 'base'
         },
         'haproxy': {
+            'disabled': True
+        },
+        'file_output': {
             'disabled': True
         },
         'nginx': nginx_config

--- a/src/tests/configure_synapse_test.py
+++ b/src/tests/configure_synapse_test.py
@@ -596,6 +596,7 @@ def test_generate_configuration_with_nginx(mock_get_current_location, mock_avail
             }],
             'discovery': {'method': 'base'},
             'haproxy': {'disabled': True},
+            'file_output': {'disabled': True},
             'nginx': {
                 'mode': 'http',
                 'port': 1234,
@@ -740,6 +741,7 @@ def test_generate_configuration_only_nginx(mock_get_current_location, mock_avail
             }],
             'discovery': {'method': 'base'},
             'haproxy': {'disabled': True},
+            'file_output': {'disabled': True},
             'nginx': {
                 'mode': 'http',
                 'port': 1234,


### PR DESCRIPTION
While testing in dev I noticed that we had a bunch of service files being generated for the nginx listeners, which we probably don't want.