### PR TITLE
Tries to make NGINX a more proper interactive proxy

### DIFF
--- a/dockerfiles/itest/itest/synapse-tools-both.conf.json
+++ b/dockerfiles/itest/itest/synapse-tools-both.conf.json
@@ -4,5 +4,7 @@
   "stats_port": 32123,
   "haproxy.defaults.inter": "10s",
   "listen_with_nginx": true,
-  "listen_with_haproxy": true
+  "listen_with_haproxy": true,
+  "haproxy_restart_interval_s": 2,
+  "nginx_restart_interval_s": 2
 }

--- a/dockerfiles/itest/itest/synapse-tools-nginx.conf.json
+++ b/dockerfiles/itest/itest/synapse-tools-nginx.conf.json
@@ -4,5 +4,7 @@
   "stats_port": 32123,
   "haproxy.defaults.inter": "10s",
   "listen_with_haproxy": false,
-  "listen_with_nginx": true
+  "listen_with_nginx": true,
+  "haproxy_restart_interval_s": 2,
+  "nginx_restart_interval_s": 2
 }

--- a/dockerfiles/itest/itest/synapse-tools.conf.json
+++ b/dockerfiles/itest/itest/synapse-tools.conf.json
@@ -2,5 +2,7 @@
   "config_file": "/etc/synapse/synapse.conf.json",
   "bind_addr": "0.0.0.0",
   "stats_port": 32123,
-  "haproxy.defaults.inter": "10s"
+  "haproxy.defaults.inter": "10s",
+  "haproxy_restart_interval_s": 2,
+  "nginx_restart_interval_s": 2
 }

--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -41,6 +41,7 @@ def set_defaults(config):
         ('haproxy_reload_cmd_fmt', """sudo /usr/bin/synapse_qdisc_tool protect bash -c 'touch {haproxy_pid_file_path} && PID=$(cat {haproxy_pid_file_path}) && {haproxy_path} -f {haproxy_config_path} -p {haproxy_pid_file_path} -sf $PID && sleep 0.010'"""),
         ('haproxy_service_sockets_path_fmt',
             '/var/run/synapse/sockets/{service_name}.sock'),
+        ('haproxy_restart_interval_s', 60),
         # Misc options
         ('file_output_path', '/var/run/synapse/services'),
         ('maximum_connections', 10000),
@@ -67,7 +68,11 @@ def set_defaults(config):
             'mkdir -p {nginx_prefix} && (kill -0 $(cat {nginx_pid_file_path}) || '
             '{nginx_path} -c {nginx_config_path} -p {nginx_prefix})'),
         ('nginx_check_cmd_fmt',
-            '{nginx_path} -t -c {nginx_config_path}')
+            '{nginx_path} -t -c {nginx_config_path}'),
+        # Nginx only has to restart for adding or removing new listeners
+        # (aka services) This should be relatively rare so we crank up the
+        # restart_interval to limit memory consumption.
+        ('nginx_restart_interval_s', 600),
     ]
 
     for k, v in defaults:
@@ -105,14 +110,21 @@ def _generate_nginx_top_level(synapse_tools_config):
                 'server_tokens off',
                 'proxy_pass_header Server',
                 'proxy_pass_header Connection',
+                'proxy_pass_header Date',
                 # By default nginx will overwrite your Host and Connection
                 # headers, this breaks things so we turn it off
+                # Also for proper websocket support we can't strip the Upgrade
+                # header either...
                 'proxy_set_header Host $http_host',
                 'proxy_set_header Connection $http_connection',
+                'proxy_set_header Upgrade $http_upgrade',
                 # We don't have variable speed clients, don't buffer things
+                # Also set buffer sizes to 16k like HAProxy does
                 'proxy_buffering off',
+                'proxy_buffer_size 16k',
+                'proxy_buffers 4 16k',
                 'proxy_request_buffering off',
-                'client_max_body_size 0',
+                'proxy_max_temp_file_size 0',
                 'proxy_http_version 1.1',
                 'proxy_redirect off',
                 # If the client sends bad headers, so be it, proxy them
@@ -140,10 +152,7 @@ def _generate_nginx_top_level(synapse_tools_config):
         ),
         'do_writes': True,
         'do_reloads': True,
-        # Only has to restart for adding or removing new listeners (aka services)
-        # This should be relatively rare so we crank up the restart_interval
-        # to limit memory consumption.
-        'restart_interval': 600,
+        'restart_interval': synapse_tools_config['nginx_restart_interval_s'],
         'restart_jitter': 0.1,
         'listen_address': synapse_tools_config['bind_addr'],
     }
@@ -153,7 +162,7 @@ def _generate_haproxy_top_level(synapse_tools_config):
     haproxy_inter = synapse_tools_config['haproxy.defaults.inter']
     return {
         'bind_address': synapse_tools_config['bind_addr'],
-        'restart_interval': 60,
+        'restart_interval': synapse_tools_config['haproxy_restart_interval_s'],
         'restart_jitter': 0.1,
         'state_file_path': '/var/run/synapse/state.json',
         'state_file_ttl': 30 * 60,

--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -100,8 +100,25 @@ def _generate_nginx_top_level(synapse_tools_config):
                 'sendfile on',
                 'tcp_nopush on',
                 'tcp_nodelay on',
+                # Fix silly nginx header defaults, we're a proxy, don't
+                # fudge with the traffic!
                 'server_tokens off',
                 'proxy_pass_header Server',
+                'proxy_pass_header Connection',
+                # By default nginx will overwrite your Host and Connection
+                # headers, this breaks things so we turn it off
+                'proxy_set_header Host $http_host',
+                'proxy_set_header Connection $http_connection',
+                # We don't have variable speed clients, don't buffer things
+                'proxy_buffering off',
+                'proxy_request_buffering off',
+                'client_max_body_size 0',
+                'proxy_http_version 1.1',
+                'proxy_redirect off',
+                # If the client sends bad headers, so be it, proxy them
+                # faithfully
+                'ignore_invalid_headers off',
+                'underscores_in_headers on',
             ],
             'events': [
                 'worker_connections {0}'.format(

--- a/src/tests/configure_synapse_test.py
+++ b/src/tests/configure_synapse_test.py
@@ -598,11 +598,10 @@ def test_generate_configuration_with_nginx(mock_get_current_location, mock_avail
             'haproxy': {'disabled': True},
             'file_output': {'disabled': True},
             'nginx': {
-                'mode': 'http',
+                'mode': 'tcp',
                 'port': 1234,
                 'server': [
-                    'proxy_send_timeout 3610s',
-                    'proxy_read_timeout 3610s'
+                    'proxy_timeout 3610s',
                 ],
                 'listen_options': 'reuseport',
             },
@@ -743,11 +742,10 @@ def test_generate_configuration_only_nginx(mock_get_current_location, mock_avail
             'haproxy': {'disabled': True},
             'file_output': {'disabled': True},
             'nginx': {
-                'mode': 'http',
+                'mode': 'tcp',
                 'port': 1234,
                 'server': [
-                    'proxy_send_timeout 3610s',
-                    'proxy_read_timeout 3610s'
+                    'proxy_timeout 3610s',
                 ]
             },
             'use_previous_backends': True


### PR DESCRIPTION
A lot of this is cribbed from [k8ns](https://github.com/kubernetes/ingress/blob/master/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl) and nginx docs on [reverse proxying](https://www.nginx.com/resources/admin-guide/reverse-proxy/) and [websockets](http://nginx.org/en/docs/http/websocket.html). Doing some manual testing indicates that the proper headers are passed now.

I increased the buffers because HAProxy has [16k buffers](https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#3.2-tune.bufsize) instead of 8k by default.

proxy_max_temp_file_size is set to 0 to prevent any buffering of responses to files (wth why would you ever do that :-( )

More [sources](https://serverfault.com/questions/768693/nginx-how-to-completely-disable-request-body-buffering).

@jnb @EvanKrall heads up
