### PR TITLE
Remove listen options and prepare for the state switch

### DIFF
--- a/src/debian/changelog
+++ b/src/debian/changelog
@@ -1,3 +1,11 @@
+synapse-tools (0.13.0) lucid; urgency=low
+
+  * Support HAProxy 1.7 via state file and allredisp options
+  * Refactors all listen options to frontend + backend
+  * Adds support for keepalives
+
+ -- Joseph Lynch <jlynch@yelp.com>  Mon, 10 Jul 2017 11:29:50 -0700
+
 synapse-tools (0.12.4) lucid; urgency=low
 
   * Switch nginx listeners to just using TCP mode

--- a/src/setup.py
+++ b/src/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='synapse-tools',
-    version='0.12.4',
+    version='0.13.0',
     provides=['synapse_tools'],
     author='John Billings',
     author_email='billings@yelp.com',

--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -562,7 +562,7 @@ def _generate_haproxy_for_watcher(service_name, service_info, synapse_tools_conf
     if balance is not None and balance in ('leastconn', 'roundrobin'):
         backend_options.append('balance %s' % balance)
 
-    keepalive = service_info.get('keepalive', False):
+    keepalive = service_info.get('keepalive', False)
     if keepalive and mode == 'http':
         backend_options.extend([
             'no option forceclose',
@@ -620,16 +620,16 @@ def _generate_haproxy_for_watcher(service_name, service_info, synapse_tools_conf
     if allredisp is not None and allredisp:
         backend_options.append('option allredisp')
 
+    timeout_connect_ms = service_info.get('timeout_connect_ms')
+
+    if timeout_connect_ms is not None:
+        backend_options.append('timeout connect %dms' % timeout_connect_ms)
+
     timeout_server_ms = service_info.get(
         'timeout_server_ms', default_timeout
     )
     if timeout_server_ms is not None:
         backend_options.append('timeout server %dms' % timeout_server_ms)
-
-    timeout_connect_ms = service_info.get('timeout_connect_ms')
-
-    if timeout_connect_ms is not None:
-        backend_options.append('timeout connect %dms' % timeout_connect_ms)
 
     return {
         'server_options': server_options,

--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -6,6 +6,7 @@ import filecmp
 import json
 import os
 import shutil
+import socket
 import subprocess
 import tempfile
 
@@ -145,6 +146,7 @@ def _generate_haproxy_top_level(synapse_tools_config):
         'do_writes': True,
         'do_reloads': True,
         'do_socket': True,
+        'server_order_seed': hash(socket.gethostname()),
 
         'global': [
             'daemon',

--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -535,7 +535,8 @@ def _generate_haproxy_for_watcher(service_name, service_info, synapse_tools_conf
     )
 
     # Frontend options
-    # All things related to the listen socket on HAProxy
+    # All things related to the listening sockets on HAProxy
+    # These are what clients connect to
     frontend_options = []
     timeout_client_ms = service_info.get(
         'timeout_client_ms', default_timeout
@@ -570,6 +571,8 @@ def _generate_haproxy_for_watcher(service_name, service_info, synapse_tools_conf
         ])
 
     if mode == 'tcp':
+        # We need to put the frontend and backend into tcp mode
+        frontend_options.append('mode tcp')
         backend_options.append('mode tcp')
 
     if is_proxy:

--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -38,7 +38,8 @@ def set_defaults(config):
         ('haproxy_path', '/usr/bin/haproxy-synapse'),
         ('haproxy_config_path', '/var/run/synapse/haproxy.cfg'),
         ('haproxy_pid_file_path', '/var/run/synapse/haproxy.pid'),
-        ('haproxy_reload_cmd_fmt', """sudo /usr/bin/synapse_qdisc_tool protect bash -c 'touch {haproxy_pid_file_path} && PID=$(cat {haproxy_pid_file_path}) && {haproxy_path} -f {haproxy_config_path} -p {haproxy_pid_file_path} -sf $PID && sleep 0.010'"""),
+        ('haproxy_state_file_path', None),
+        ('haproxy_reload_cmd_fmt', """touch {haproxy_pid_file_path} && PID=$(cat {haproxy_pid_file_path}) && {haproxy_path} -f {haproxy_config_path} -p {haproxy_pid_file_path} -sf $PID"""),
         ('haproxy_service_sockets_path_fmt',
             '/var/run/synapse/sockets/{service_name}.sock'),
         ('haproxy_restart_interval_s', 60),
@@ -131,7 +132,7 @@ def _generate_nginx_top_level(synapse_tools_config):
 
 def _generate_haproxy_top_level(synapse_tools_config):
     haproxy_inter = synapse_tools_config['haproxy.defaults.inter']
-    return {
+    top_level = {
         'bind_address': synapse_tools_config['bind_addr'],
         'restart_interval': synapse_tools_config['haproxy_restart_interval_s'],
         'restart_jitter': 0.1,
@@ -147,7 +148,9 @@ def _generate_haproxy_top_level(synapse_tools_config):
         'global': [
             'daemon',
             'maxconn %d' % synapse_tools_config['maximum_connections'],
-            'stats socket %s level admin' % synapse_tools_config['haproxy_socket_file_path'],
+            'stats socket {0} level admin'.format(
+                synapse_tools_config['haproxy_socket_file_path']
+            ),
 
             # Default of 16k is too small and causes HTTP 400 errors
             'tune.bufsize 32768',
@@ -169,8 +172,8 @@ def _generate_haproxy_top_level(synapse_tools_config):
             'timeout server 1000ms',
 
             # On failure, try a different server
-            'retries 1',
-            'option redispatch',
+            'retries 2',
+            'option redispatch 1',
 
             # The server with the lowest number of connections receives the
             # connection by default
@@ -232,6 +235,19 @@ def _generate_haproxy_top_level(synapse_tools_config):
             ]
         }
     }
+
+    # Just for the migration to HAProxy 1.7, when SMTSTK-190 is done
+    # always have this enabled and set the default to a sane default instead
+    # of None
+    if synapse_tools_config.get('haproxy_state_file_path'):
+        top_level['global'].append(
+            'server-state-file {0}'.format(
+                synapse_tools_config.get('haproxy_state_file_path')
+            )
+        )
+        top_level['defaults'].append('load-server-state-from-file global')
+
+    return top_level
 
 
 def generate_base_config(synapse_tools_config):
@@ -551,7 +567,7 @@ def _generate_haproxy_for_watcher(service_name, service_info, synapse_tools_conf
         backend_options.extend([
             'no option forceclose',
             'option http-keep-alive'
-        ]
+        ])
 
     if mode == 'tcp':
         backend_options.append('mode tcp')

--- a/src/tests/configure_synapse_test.py
+++ b/src/tests/configure_synapse_test.py
@@ -123,14 +123,7 @@ def test_generate_configuration(mock_get_current_location, mock_available_locati
                 ],
             },
             'haproxy': {
-                'listen': [
-                    'option httpchk GET /http/test_service/0/status HTTP/1.1\\r\\nX-Mode:\\ ro',
-                    'http-check send-state',
-                    'retries 2',
-                    'timeout connect 2000ms',
-                    'timeout server 3000ms',
-                    'balance roundrobin',
-                ],
+                'listen': [],
                 'frontend': [
                     'timeout client 3000ms',
                     'capture request header X-B3-SpanId len 64',
@@ -146,8 +139,14 @@ def test_generate_configuration(mock_get_current_location, mock_available_locati
                     'use_backend test_service.superregion if test_service.superregion_has_connslots',
                 ],
                 'backend': [
+                    'balance roundrobin',
                     'reqidel ^X-Mode:.*',
                     'reqadd X-Mode:\ ro',
+                    'option httpchk GET /http/test_service/0/status HTTP/1.1\\r\\nX-Mode:\\ ro',
+                    'http-check send-state',
+                    'retries 2',
+                    'timeout connect 2000ms',
+                    'timeout server 3000ms',
                 ],
                 'port': '1234',
                 'server_options': 'check port 6666 observe layer7 maxconn 50 maxqueue 10',
@@ -170,17 +169,16 @@ def test_generate_configuration(mock_get_current_location, mock_available_locati
                 ],
             },
             'haproxy': {
-                'listen': [
+                'listen': [],
+                'backend': [
+                    'balance roundrobin',
+                    'reqidel ^X-Mode:.*',
+                    'reqadd X-Mode:\ ro',
                     'option httpchk GET /http/test_service/0/status HTTP/1.1\\r\\nX-Mode:\\ ro',
                     'http-check send-state',
                     'retries 2',
                     'timeout connect 2000ms',
                     'timeout server 3000ms',
-                    'balance roundrobin',
-                ],
-                'backend': [
-                    'reqidel ^X-Mode:.*',
-                    'reqadd X-Mode:\ ro',
                 ],
                 'server_options': 'check port 6666 observe layer7 maxconn 50 maxqueue 10',
                 'backend_name': 'test_service.superregion',
@@ -224,7 +222,7 @@ def test_generate_configuration_single_advertise(mock_get_current_location, mock
                 {
                     'proxy_port': 1234,
                     'healthcheck_uri': '/status',
-                    'retries': 2,
+                    'retries': 3,
                     'timeout_connect_ms': 2000,
                     'timeout_server_ms': 3000,
                     'extra_headers': {
@@ -250,7 +248,7 @@ def test_generate_configuration_single_advertise(mock_get_current_location, mock
                 {
                     'proxy_port': 1234,
                     'healthcheck_uri': '/status',
-                    'retries': 2,
+                    'retries': 3,
                     'timeout_connect_ms': 2000,
                     'timeout_server_ms': 3000,
                     'extra_headers': {
@@ -285,14 +283,7 @@ def test_generate_configuration_single_advertise(mock_get_current_location, mock
                 ],
             },
             'haproxy': {
-                'listen': [
-                    'option httpchk GET /http/test_service/0/status HTTP/1.1\\r\\nX-Mode:\\ ro',
-                    'http-check send-state',
-                    'retries 2',
-                    'timeout connect 2000ms',
-                    'timeout server 3000ms',
-                    'balance roundrobin',
-                ],
+                'listen': [],
                 'frontend': [
                     'timeout client 3000ms',
                     'capture request header X-B3-SpanId len 64',
@@ -306,8 +297,14 @@ def test_generate_configuration_single_advertise(mock_get_current_location, mock
                     'use_backend test_service if test_service_has_connslots',
                 ],
                 'backend': [
+                    'balance roundrobin',
                     'reqidel ^X-Mode:.*',
                     'reqadd X-Mode:\ ro',
+                    'option httpchk GET /http/test_service/0/status HTTP/1.1\\r\\nX-Mode:\\ ro',
+                    'http-check send-state',
+                    'retries 3',
+                    'timeout connect 2000ms',
+                    'timeout server 3000ms',
                 ],
                 'port': '1234',
                 'server_options': 'check port 6666 observe layer7 maxconn 50 maxqueue 10',
@@ -389,11 +386,7 @@ def test_generate_configuration_with_proxied_through(mock_get_current_location, 
                 ],
             },
             'haproxy': {
-                'listen': [
-                    'option httpchk GET /http/proxy_service/0/status',
-                    'http-check send-state',
-                    'balance roundrobin',
-                ],
+                'listen': [],
                 'frontend': [
                     'capture request header X-B3-SpanId len 64',
                     'capture request header X-B3-TraceId len 64',
@@ -406,8 +399,11 @@ def test_generate_configuration_with_proxied_through(mock_get_current_location, 
                     'use_backend proxy_service if proxy_service_has_connslots',
                 ],
                 'backend': [
+                    'balance roundrobin',
                     'acl is_status_request path /status',
                     'reqadd X-Smartstack-Source:\\ proxy_service if !is_status_request',
+                    'option httpchk GET /http/proxy_service/0/status',
+                    'http-check send-state',
                 ],
                 'port': '5678',
                 'server_options': 'check port 6666 observe layer7 maxconn 50 maxqueue 10',
@@ -431,12 +427,6 @@ def test_generate_configuration_with_proxied_through(mock_get_current_location, 
             },
             'haproxy': {
                 'listen': [
-                    'option httpchk GET /http/test_service/0/status HTTP/1.1\\r\\nX-Mode:\\ ro',
-                    'http-check send-state',
-                    'retries 2',
-                    'timeout connect 2000ms',
-                    'timeout server 3000ms',
-                    'balance roundrobin',
                 ],
                 'frontend': [
                     'timeout client 3000ms',
@@ -456,8 +446,14 @@ def test_generate_configuration_with_proxied_through(mock_get_current_location, 
                     'use_backend test_service if test_service_has_connslots',
                 ],
                 'backend': [
+                    'balance roundrobin',
                     'reqidel ^X-Mode:.*',
                     'reqadd X-Mode:\ ro',
+                    'option httpchk GET /http/test_service/0/status HTTP/1.1\\r\\nX-Mode:\\ ro',
+                    'http-check send-state',
+                    'retries 2',
+                    'timeout connect 2000ms',
+                    'timeout server 3000ms',
                 ],
                 'port': '1234',
                 'server_options': 'check port 6666 observe layer7 maxconn 50 maxqueue 10',
@@ -520,14 +516,7 @@ def test_generate_configuration_with_nginx(mock_get_current_location, mock_avail
                 ],
             },
             'haproxy': {
-                'listen': [
-                    'option httpchk GET /http/test_service/0/status HTTP/1.1\\r\\nX-Mode:\\ ro',
-                    'http-check send-state',
-                    'retries 2',
-                    'timeout connect 2000ms',
-                    'timeout server 3000ms',
-                    'balance roundrobin',
-                ],
+                'listen': [],
                 'frontend': [
                     'timeout client 3000ms',
                     'capture request header X-B3-SpanId len 64',
@@ -543,8 +532,14 @@ def test_generate_configuration_with_nginx(mock_get_current_location, mock_avail
                     'use_backend test_service.superregion if test_service.superregion_has_connslots',
                 ],
                 'backend': [
+                    'balance roundrobin',
                     'reqidel ^X-Mode:.*',
                     'reqadd X-Mode:\ ro',
+                    'option httpchk GET /http/test_service/0/status HTTP/1.1\\r\\nX-Mode:\\ ro',
+                    'http-check send-state',
+                    'retries 2',
+                    'timeout connect 2000ms',
+                    'timeout server 3000ms',
                 ],
                 'port': '1234',
                 'server_options': 'check port 6666 observe layer7 maxconn 50 maxqueue 10',
@@ -570,17 +565,16 @@ def test_generate_configuration_with_nginx(mock_get_current_location, mock_avail
                 ],
             },
             'haproxy': {
-                'listen': [
+                'listen': [],
+                'backend': [
+                    'balance roundrobin',
+                    'reqidel ^X-Mode:.*',
+                    'reqadd X-Mode:\ ro',
                     'option httpchk GET /http/test_service/0/status HTTP/1.1\\r\\nX-Mode:\\ ro',
                     'http-check send-state',
                     'retries 2',
                     'timeout connect 2000ms',
                     'timeout server 3000ms',
-                    'balance roundrobin',
-                ],
-                'backend': [
-                    'reqidel ^X-Mode:.*',
-                    'reqadd X-Mode:\ ro',
                 ],
                 'server_options': 'check port 6666 observe layer7 maxconn 50 maxqueue 10',
                 'backend_name': 'test_service.superregion',
@@ -664,14 +658,7 @@ def test_generate_configuration_only_nginx(mock_get_current_location, mock_avail
                 ],
             },
             'haproxy': {
-                'listen': [
-                    'option httpchk GET /http/test_service/0/status HTTP/1.1\\r\\nX-Mode:\\ ro',
-                    'http-check send-state',
-                    'retries 2',
-                    'timeout connect 2000ms',
-                    'timeout server 3000ms',
-                    'balance roundrobin',
-                ],
+                'listen': [],
                 'frontend': [
                     'timeout client 3000ms',
                     'capture request header X-B3-SpanId len 64',
@@ -686,8 +673,14 @@ def test_generate_configuration_only_nginx(mock_get_current_location, mock_avail
                     'use_backend test_service.superregion if test_service.superregion_has_connslots',
                 ],
                 'backend': [
+                    'balance roundrobin',
                     'reqidel ^X-Mode:.*',
                     'reqadd X-Mode:\ ro',
+                    'option httpchk GET /http/test_service/0/status HTTP/1.1\\r\\nX-Mode:\\ ro',
+                    'http-check send-state',
+                    'retries 2',
+                    'timeout connect 2000ms',
+                    'timeout server 3000ms',
                 ],
                 'bind_address': '/var/run/synapse/sockets/test_service.sock',
                 'server_options': 'check port 6666 observe layer7 maxconn 50 maxqueue 10',
@@ -714,17 +707,16 @@ def test_generate_configuration_only_nginx(mock_get_current_location, mock_avail
                 ],
             },
             'haproxy': {
-                'listen': [
+                'listen': [],
+                'backend': [
+                    'balance roundrobin',
+                    'reqidel ^X-Mode:.*',
+                    'reqadd X-Mode:\ ro',
                     'option httpchk GET /http/test_service/0/status HTTP/1.1\\r\\nX-Mode:\\ ro',
                     'http-check send-state',
                     'retries 2',
                     'timeout connect 2000ms',
                     'timeout server 3000ms',
-                    'balance roundrobin',
-                ],
-                'backend': [
-                    'reqidel ^X-Mode:.*',
-                    'reqadd X-Mode:\ ro',
                 ],
                 'server_options': 'check port 6666 observe layer7 maxconn 50 maxqueue 10',
                 'backend_name': 'test_service.superregion',

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -4,7 +4,7 @@
 basepython=python2.7
 install_command = pip install --no-use-wheel --upgrade {opts} {packages}
 deps =
-    -r/work/src/requirements.txt
+    -r{toxinidir}/requirements.txt
     flake8
     pytest
     mock==1.0.1


### PR DESCRIPTION
Some cleanup:
- Synapse was never putting listen_options into listen sections, it was just splitting/duplicating them into frontend/backend sections. For less confusion we just do backend and frontend options

Some new features to support next steps on synapse plugins
- support for state file
- option redispatch -> option redispatch 1 (sneaky way to get allredisp in there)

A new feature because why not
- support for http keep alive (might help ES switch to smartstack load balancing)