### PR TITLE
Fix deploy to bintray, use tags, add README badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,5 @@ deploy:
     key:
       secure: "F9DHZln0Zp1/A/ZvhXyn7ff55WAo8Df2NuS1/TZshXXbWpc5LXbxFrPHtoP5gBG+BuH7MnYzm4g0S1lECxbSs+fuiBE4C3nfnk8hXfl31o451WQQnjOhtJ0BHXoA2LqTd9gFFZETTGz6IGioP7sc0LrzJ7XR2iMaPSBGraZTvUQM5hodKIQ3Nfv2qbSbPyV4zAe54ukO4rn4lxqgTeDKjcbpU797QWokuePfvqa2wKShrtsWqW/mJ3vDKB3aimGPXC8TRXp1tEdF0jJIfX4nLO3HEnOMQgwRGu1Dk2/BlQvL+k8ZUEt2iNhkkh/ZpBIFmWC/vhj40zEAk3uPs3JTavULvCHQ81/UMJjA+fBve9INp93kvjC1udJCMn2FNF7fVj8xeVcSq7XIFzk/Buqn40b9AaMX80iow+8hJ68vm/r6U8U/K19azgmKCQWDYYtCmLmuNRi6TTQvF7ToyfQxNrgq8MNp6akCA7L0lad0IWhm/haV5wvOpem5ozuRwZgf8Yh9aryLt3NngndqEw51RC4onqyw1ytEtqCh1UDrJgzRJZuJozz0s3Yv7OZc09w9i4aRji6Tzd2mrfpKrjBJzIUFOAist1W0wzNsJu1flxAjh6pYvYp6wYeMxU1zsz808/c4cTbUHpmJYONmgzn/+zLqQiAXDIX5Ye1KgEE1bsI="
     on:
-      branch: master
+      tags: true
       repo: Yelp/synapse-tools

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 DATE := $(shell date +'%Y-%m-%d')
 SYNAPSETOOLSVERSION := $(shell sed 's/.*(\(.*\)).*/\1/;q' src/debian/changelog)
-bintray.json: bintray.json.in src/debian/changelog
-	sed -e 's/@DATE@/$(DATE)/g' -e 's/@SYNAPSETOOLSVERSION@/$(SYNAPSETOOLSVERSION)/g' $< > $@
+bintray_%: bintray.json.in src/debian/changelog
+	sed -e 's/@DATE@/$(DATE)/g' \
+	    -e 's/@SYNAPSETOOLSVERSION@/$(SYNAPSETOOLSVERSION)/g' \
+	    -e 's/@DISTRIBUTION@/$*/g' \
+            bintray.json.in > bintray.json
 
-itest_%: package_%
+itest_%: package_% bintray_%
 	rm -rf dockerfiles/itest/itest_$*
 	cp -a dockerfiles/itest/itest dockerfiles/itest/itest_$*
 	cp dockerfiles/itest/itest/Dockerfile.$* dockerfiles/itest/itest_$*/Dockerfile

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ synapse-tools
 =============
 
 [![Build Status](https://travis-ci.org/Yelp/synapse-tools.svg?branch=master)](https://travis-ci.org/Yelp/synapse-tools)
+[![Download](https://api.bintray.com/packages/yelp/paasta/synapse-tools/images/download.svg)](https://bintray.com/yelp/paasta/synapse-tools/_latestVersion)
+
 
 Tools for working with [synapse](https://github.com/airbnb/synapse).
 This repo builds as a [dh_virtualenv](https://github.com/spotify/dh-virtualenv) package, and provides three entry points:

--- a/bintray.json.in
+++ b/bintray.json.in
@@ -27,7 +27,15 @@
 
     "files":
         [
-        {"includePattern": "dist/(synapse-tools.*\.deb)", "uploadPattern": "$1", "matrixParams": { "deb_distribution": "trusty", "deb_component": "main", "deb_architecture": "amd64"} }
+            {
+                "includePattern": "dist/(synapse-tools.*\.deb)",
+                "uploadPattern": "$1",
+                "matrixParams": {
+                    "deb_distribution": "@DISTRIBUTION@",
+                    "deb_component": "main",
+                    "deb_architecture": "amd64"
+                }
+            }
         ],
     "publish": true
 }


### PR DESCRIPTION
The deploy has been broken since 316010e3, when `bintray.json` was removed from the Makefile, so this adds that functionality back and does per-distribution deploys like done with paasta-tools.

This also switches to use tags for deploys, since we do actually tag releases now (originally changed to master branch in 295c4d7e when tags weren't used for this repo)