### PR TITLE
Rename the proxy unix socket to be shorter

### DIFF
--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -45,7 +45,7 @@ def set_defaults(config):
         ('haproxy_service_sockets_path_fmt',
             '/var/run/synapse/sockets/{service_name}.sock'),
         ('haproxy_service_proxy_sockets_path_fmt',
-            '/var/run/synapse/sockets/{service_name}.proxy_sock'),
+            '/var/run/synapse/sockets/{service_name}.prxy'),
         ('haproxy_restart_interval_s', 60),
         # Misc options
         ('file_output_path', '/var/run/synapse/services'),

--- a/src/tests/configure_synapse_test.py
+++ b/src/tests/configure_synapse_test.py
@@ -133,7 +133,7 @@ def test_generate_configuration(mock_get_current_location, mock_available_locati
                     'capture request header X-B3-Sampled len 10',
                     'option httplog',
                     'bind /var/run/synapse/sockets/test_service.sock',
-                    'bind /var/run/synapse/sockets/test_service.proxy_sock accept-proxy',
+                    'bind /var/run/synapse/sockets/test_service.prxy accept-proxy',
                     'acl test_service_has_connslots connslots(test_service) gt 0',
                     'use_backend test_service if test_service_has_connslots',
                     'acl test_service.superregion_has_connslots connslots(test_service.superregion) gt 0',
@@ -294,7 +294,7 @@ def test_generate_configuration_single_advertise(mock_get_current_location, mock
                     'capture request header X-B3-Sampled len 10',
                     'option httplog',
                     'bind /var/run/synapse/sockets/test_service.sock',
-                    'bind /var/run/synapse/sockets/test_service.proxy_sock accept-proxy',
+                    'bind /var/run/synapse/sockets/test_service.prxy accept-proxy',
                     'acl test_service_has_connslots connslots(test_service) gt 0',
                     'use_backend test_service if test_service_has_connslots',
                 ],
@@ -397,7 +397,7 @@ def test_generate_configuration_with_proxied_through(mock_get_current_location, 
                     'capture request header X-B3-Sampled len 10',
                     'option httplog',
                     'bind /var/run/synapse/sockets/proxy_service.sock',
-                    'bind /var/run/synapse/sockets/proxy_service.proxy_sock accept-proxy',
+                    'bind /var/run/synapse/sockets/proxy_service.prxy accept-proxy',
                     'acl proxy_service_has_connslots connslots(proxy_service) gt 0',
                     'use_backend proxy_service if proxy_service_has_connslots',
                 ],
@@ -440,7 +440,7 @@ def test_generate_configuration_with_proxied_through(mock_get_current_location, 
                     'capture request header X-B3-Sampled len 10',
                     'option httplog',
                     'bind /var/run/synapse/sockets/test_service.sock',
-                    'bind /var/run/synapse/sockets/test_service.proxy_sock accept-proxy',
+                    'bind /var/run/synapse/sockets/test_service.prxy accept-proxy',
                     'acl is_status_request path /status',
                     'acl request_from_proxy hdr_beg(X-Smartstack-Source) -i proxy_service',
                     'acl proxied_through_backend_has_connslots connslots(proxy_service) gt 0',
@@ -530,7 +530,7 @@ def test_generate_configuration_with_nginx(mock_get_current_location, mock_avail
                     'capture request header X-B3-Sampled len 10',
                     'option httplog',
                     'bind /var/run/synapse/sockets/test_service.sock',
-                    'bind /var/run/synapse/sockets/test_service.proxy_sock accept-proxy',
+                    'bind /var/run/synapse/sockets/test_service.prxy accept-proxy',
                     'acl test_service_has_connslots connslots(test_service) gt 0',
                     'use_backend test_service if test_service_has_connslots',
                     'acl test_service.superregion_has_connslots connslots(test_service.superregion) gt 0',
@@ -672,7 +672,7 @@ def test_generate_configuration_only_nginx(mock_get_current_location, mock_avail
                     'capture request header X-B3-Flags len 10',
                     'capture request header X-B3-Sampled len 10',
                     'option httplog',
-                    'bind /var/run/synapse/sockets/test_service.proxy_sock accept-proxy',
+                    'bind /var/run/synapse/sockets/test_service.prxy accept-proxy',
                     'acl test_service_has_connslots connslots(test_service) gt 0',
                     'use_backend test_service if test_service_has_connslots',
                     'acl test_service.superregion_has_connslots connslots(test_service.superregion) gt 0',
@@ -971,7 +971,7 @@ def test_nginx_no_proxy_proto(mock_get_current_location, mock_available_location
     # Check HAProxy binds on both PROXY protocol and regular TCP unix sockets
     frontend = actual_configuration['services']['test_service']['haproxy']['frontend']
     assert 'bind /var/run/synapse/sockets/test_service.sock' in frontend
-    assert 'bind /var/run/synapse/sockets/test_service.proxy_sock accept-proxy' in frontend
+    assert 'bind /var/run/synapse/sockets/test_service.prxy accept-proxy' in frontend
 
     # Check nginx doesn't send regular tcp traffic to the proxy socket
     nginx = actual_configuration['services']['test_service.nginx_listener']
@@ -995,9 +995,9 @@ def test_nginx_proxy_proto(mock_get_current_location, mock_available_location_ty
     # Check HAProxy binds on both PROXY protocol and regular TCP unix sockets
     frontend = actual_configuration['services']['test_service']['haproxy']['frontend']
     assert 'bind /var/run/synapse/sockets/test_service.sock' in frontend
-    assert 'bind /var/run/synapse/sockets/test_service.proxy_sock accept-proxy' in frontend
+    assert 'bind /var/run/synapse/sockets/test_service.prxy accept-proxy' in frontend
 
     # Check nginx sends PROXY protocol traffic to the correct socket when enabled
     nginx = actual_configuration['services']['test_service.nginx_listener']
-    assert nginx['default_servers'][0]['port'] == '/var/run/synapse/sockets/test_service.proxy_sock'
+    assert nginx['default_servers'][0]['port'] == '/var/run/synapse/sockets/test_service.prxy'
     assert 'proxy_protocol on' in nginx['nginx']['server']


### PR DESCRIPTION
This makes it the same length as the regular unix socket which is better for consistency and should make it easier to add a length limit to smartstack namespaces.