### PR TITLE
Use stop + start instead of restart on Synapse

### DIFF
--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -52,7 +52,7 @@ def set_defaults(config):
         ('maximum_connections', 10000),
         ('maxconn_per_server', 50),
         ('maxqueue_per_server', 10),
-        ('synapse_restart_command', ['service', 'synapse', 'restart']),
+        ('synapse_command', ['service', 'synapse']),
         ('zookeeper_topology_path',
             '/nail/etc/zookeeper_discovery/infrastructure/local.yaml'),
         ('hacheck_port', 6666),
@@ -818,7 +818,17 @@ def main():
         shutil.copy(new_synapse_config_path, my_config['config_file'])
 
         if should_restart:
-            subprocess.check_call(my_config['synapse_restart_command'])
+            # backwards compatibility for synapse_restart_command
+            # Note that it's preferable to use synapse_command
+            if 'synapse_restart_command' in my_config:
+                subprocess.check_call(my_config['synapse_restart_command'])
+            else:
+                # Use stop + start so that we re-read the init file
+                # This is useful, for example, to ensure Synapse has good
+                # limits on file descriptors (which means HAProxy will)
+                cmd = my_config['synapse_command']
+                subprocess.check_call(cmd + ['stop'])
+                subprocess.check_call(cmd + ['start'])
 
 
 if __name__ == '__main__':

--- a/src/tests/configure_synapse_test.py
+++ b/src/tests/configure_synapse_test.py
@@ -791,7 +791,13 @@ def test_synapse_restarted_when_config_files_differ():
 
         mock_copy.assert_called_with(
             mock_tmp_file.__enter__().name, '/etc/synapse/synapse.conf.json')
-        mock_subprocess_check_call.assert_called_with(['service', 'synapse', 'restart'])
+
+        expected_calls = [
+            mock.call(['service', 'synapse', 'stop']),
+            mock.call(['service', 'synapse', 'start'])
+        ]
+
+        assert mock_subprocess_check_call.call_args_list == expected_calls
 
 
 def test_synapse_not_restarted_when_config_files_are_identical():


### PR DESCRIPTION
This fixes the issues today we've seen on dev/stage where some Synapses still had the 1024 fd limit (ugh upstart). Always be stop startin.