### PR TITLE
Remove duplicate plugin options

### DIFF
--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -501,20 +501,22 @@ def generate_configuration(synapse_tools_config, zookeeper_topology, services):
             for plugin_name in PLUGIN_MAP:
                 if plugin_name not in plugins and not synapse_tools_config.get(plugin_name):
                     continue
+
                 plugin_instance = PLUGIN_MAP[plugin_name](
                     service_name,
                     service_info,
                     synapse_tools_config
                 )
-                synapse_config['services'][service_name]['haproxy']['frontend'].extend(
-                    plugin_instance.frontend_options()
-                )
-                synapse_config['services'][service_name]['haproxy']['backend'].extend(
-                    plugin_instance.backend_options()
-                )
-                synapse_config['haproxy']['global'].extend(
-                    plugin_instance.global_options()
-                )
+                config_to_opts = [
+                    (synapse_config['services'][service_name]['haproxy']['frontend'],
+                     plugin_instance.frontend_options()),
+                    (synapse_config['services'][service_name]['haproxy']['backend'],
+                     plugin_instance.backend_options()),
+                    (synapse_config['haproxy']['global'],
+                     plugin_instance.global_options())
+                ]
+                for (config, opts) in config_to_opts:
+                    config.extend([x for x in opts if x not in config])
 
     return synapse_config
 

--- a/src/tests/configure_synapse_test.py
+++ b/src/tests/configure_synapse_test.py
@@ -944,7 +944,10 @@ def test_generate_configuration_with_multiple_plugins(mock_get_current_location,
                     'proxy_port': 5678,
                     'balance': 'roundrobin',
                     'advertise': ['region'],
-                    'discover': 'region'
+                    'discover': 'region',
+                    'plugins': {
+                        'logging': True
+                    }
                 }
             )
         ]
@@ -981,7 +984,9 @@ def test_generate_configuration_with_multiple_plugins(mock_get_current_location,
                     'bind /var/run/synapse/sockets/proxy_service.sock',
                     'bind /var/run/synapse/sockets/proxy_service.prxy accept-proxy',
                     'acl proxy_service_has_connslots connslots(proxy_service) gt 0',
-                    'use_backend proxy_service if proxy_service_has_connslots'
+                    'use_backend proxy_service if proxy_service_has_connslots',
+                    'http-request lua.load_map',
+                    'http-request lua.log_src'
                 ],
                 'backend': [
                     'balance roundrobin',
@@ -989,6 +994,7 @@ def test_generate_configuration_with_multiple_plugins(mock_get_current_location,
                     'reqadd X-Smartstack-Source:\\ proxy_service if !is_status_request',
                     'option httpchk GET /http/proxy_service/0/status',
                     'http-check send-state',
+                    'http-request lua.log_dest'
                 ],
                 'port': '5678',
                 'server_options': 'check port 6666 observe layer7 maxconn 50 maxqueue 10',


### PR DESCRIPTION
Currently, when multiple services enable the same plugin, the same global option appears multiple times in the HAProxy config, once per service. This change removes replication of plugin options. 

cc @jolynch @jvperrin @matfra 