### PR TITLE
Depend on socat so that reload commands can use it without fear

### DIFF
--- a/src/debian/control
+++ b/src/debian/control
@@ -3,7 +3,7 @@ Maintainer: John Billings <billings@yelp.com>
 Build-Depends:
     dh-virtualenv,
 
-Depends: python2.7, sudo, ${shlibs:Depends}
+Depends: python2.7, sudo, socat, ${shlibs:Depends}
 Package: synapse-tools
 Architecture: any
 Description: Synapse-related tools for use on Yelp machines.


### PR DESCRIPTION
With the upgrade to HAProxy 1.7, we started using the state file, which meant that we have to use the following restart command from synapse:
```
touch {haproxy_pid_file_path} && PID=$(cat {haproxy_pid_file_path}) && (echo show servers state | socat - {haproxy_socket_file_path} > {haproxy_state_file_path} || echo no socket) && {haproxy_path} -f {haproxy_config_path} -p {haproxy_pid_file_path} -sf $PID
```

This has the slight problem of not working when socat isn't installed, so now we do @zareenc 