### PR TITLE
PERF-2836: tarpitting requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [v0.11.5](https://github.com/Yelp/synapse-tools/tree/v0.11.5) (2018-02-13)
+[Full Changelog](https://github.com/Yelp/synapse-tools/compare/v0.11.4...v0.11.5)
+
+**Merged pull requests:**
+
+- Enable fault-injection via the use of X-Ctx-Tarpit headers [\#45](https://github.com/Yelp/synapse-tools/pull/45) ([avadhutp](https://github.com/avadhutp))
+
 ## [v0.11.4](https://github.com/Yelp/synapse-tools/tree/v0.11.4) (2017-01-10)
 [Full Changelog](https://github.com/Yelp/synapse-tools/compare/v0.11.3...v0.11.4)
 

--- a/dockerfiles/itest/itest/run_itest.sh
+++ b/dockerfiles/itest/itest/run_itest.sh
@@ -11,6 +11,12 @@ apt-get -y install -f
 echo "Testing that pyyaml uses optimized cyaml parsers if present"
 /opt/venvs/synapse-tools/bin/python -c 'import yaml; assert yaml.__with_libyaml__'
 
+source /etc/os-release
+if [[  $VERSION = *"Trusty"* ]]; then
+    echo "Trusty has issues with backports.functools_lru_cache; installing it"
+    /opt/venvs/synapse-tools/bin/pip install backports.functools_lru_cache
+fi
+
 echo "Creating directory for unix sockets"
 mkdir -p /var/run/synapse/sockets
 

--- a/src/synapse_tools/config_plugins/base.py
+++ b/src/synapse_tools/config_plugins/base.py
@@ -26,6 +26,7 @@ class HAProxyConfigPlugin(object):
         """
         return
 
+    @abc.abstractmethod
     def defaults_options(self):
         """
         Options for HAProxy configuration defaults section

--- a/src/synapse_tools/config_plugins/base.py
+++ b/src/synapse_tools/config_plugins/base.py
@@ -26,6 +26,13 @@ class HAProxyConfigPlugin(object):
         """
         return
 
+    def defaults_options(self):
+        """
+        Options for HAProxy configuration defaults section
+        :return: list of strings corresponding to distinct
+                 lines in HAProxy config defaults
+        """
+
     @abc.abstractmethod
     def frontend_options(self):
         """

--- a/src/synapse_tools/config_plugins/fault_injection.py
+++ b/src/synapse_tools/config_plugins/fault_injection.py
@@ -1,0 +1,25 @@
+from synapse_tools.config_plugins.base import HAProxyConfigPlugin
+
+
+MAX_TARPIT_TIMEOUT = '60s'
+TARPIT_HEADER = 'X-Ctx-Tarpit'
+
+
+class FaultInjection(HAProxyConfigPlugin):
+    def global_options(self):
+        return []
+
+    def defaults_options(self):
+        return ['timeout tarpit %s' % MAX_TARPIT_TIMEOUT]
+
+    def frontend_options(self):
+        return []
+
+    def backend_options(self):
+        return [
+            'acl to_be_tarpitted hdr_sub({header_name}) -i {service_name}'.format(
+                header_name=TARPIT_HEADER,
+                service_name=self.service_name,
+            ),
+            'reqtarpit . if to_be_tarpitted',
+        ]

--- a/src/synapse_tools/config_plugins/logging.py
+++ b/src/synapse_tools/config_plugins/logging.py
@@ -35,6 +35,9 @@ class Logging(HAProxyConfigPlugin):
             opts.append('setenv sample_rate {0}'.format(sample_rate))
         return opts
 
+    def defaults_options(self):
+        return []
+
     def frontend_options(self):
         return []
 

--- a/src/synapse_tools/config_plugins/path_based_routing.py
+++ b/src/synapse_tools/config_plugins/path_based_routing.py
@@ -20,6 +20,9 @@ class PathBasedRouting(HAProxyConfigPlugin):
         file_path = os.path.join(lua_dir, 'path_based_routing.lua')
         return ['lua-load %s' % file_path]
 
+    def defaults_options(self):
+        return []
+
     def frontend_options(self):
         if not self.enabled:
             return []

--- a/src/synapse_tools/config_plugins/proxied_through.py
+++ b/src/synapse_tools/config_plugins/proxied_through.py
@@ -5,6 +5,9 @@ class ProxiedThrough(HAProxyConfigPlugin):
     def global_options(self):
         return []
 
+    def defaults_options(self):
+        return []
+
     def frontend_options(self):
         if self.service_info.get('proxied_through') is None:
             return []

--- a/src/synapse_tools/config_plugins/registry.py
+++ b/src/synapse_tools/config_plugins/registry.py
@@ -1,10 +1,12 @@
 from collections import OrderedDict
 
+from synapse_tools.config_plugins.fault_injection import FaultInjection
 from synapse_tools.config_plugins.logging import Logging
 from synapse_tools.config_plugins.path_based_routing import PathBasedRouting
 from synapse_tools.config_plugins.proxied_through import ProxiedThrough
 
 PLUGIN_REGISTRY = OrderedDict([
+    ('fault_injection', FaultInjection),
     ('proxied_through', ProxiedThrough),
     ('logging', Logging),
     ('path_based_routing', PathBasedRouting)

--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -464,7 +464,9 @@ def generate_configuration(synapse_tools_config, zookeeper_topology, services):
                     (synapse_config['services'][service_name]['haproxy']['backend'],
                      plugin_instance.backend_options()),
                     (synapse_config['haproxy']['global'],
-                     plugin_instance.global_options())
+                     plugin_instance.global_options()),
+                    (synapse_config['haproxy']['defaults'],
+                     plugin_instance.defaults_options())
                 ]
                 for (config, opts) in config_to_opts:
                     config.extend([x for x in opts if x not in config])

--- a/src/synapse_tools/haproxy/qdisc_tool.py
+++ b/src/synapse_tools/haproxy/qdisc_tool.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 """ Command line interface for working with qdiscs """
 from __future__ import absolute_import
 from __future__ import division
@@ -79,7 +79,7 @@ def protect_call_cmd(args):
     try:
         try:
             manage_plug(INTERFACE_NAME, enable_plug=True)
-        except:
+        except Exception:
             # If we fail to plug, it is no big deal, we might
             # drop some traffic but let's not fail to run the
             # command
@@ -96,7 +96,7 @@ def protect_call_cmd(args):
             try:
                 manage_plug(INTERFACE_NAME, enable_plug=False)
                 break
-            except:
+            except Exception:
                 log.exception('Failed to disable plug, try #%d' % i)
 
 

--- a/src/synapse_tools/haproxy/qdisc_util.py
+++ b/src/synapse_tools/haproxy/qdisc_util.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 """ Interface for working with qdiscs """
 from __future__ import absolute_import
 from __future__ import division
@@ -119,7 +119,7 @@ def _apply_tc_rules(interface_name):
         tc['qdisc', 'add', 'dev', interface_name,
            'parent', PLUG_CLASS,
            'handle', PLUG_QDISC, 'plug']()
-    except:
+    except Exception:
         # If we can't create a plug because of an older
         # kernel, just make a fifo
         tc['qdisc', 'add', 'dev', interface_name,
@@ -165,7 +165,7 @@ def setup(interface_name, source_ip):
 def clear(interface_name, source_ip):
     try:
         tc['qdisc', 'del', 'dev', interface_name, 'root']()
-    except:
+    except Exception:
         pass
 
     # Ensure all iptables rules are purged on the output device
@@ -176,7 +176,7 @@ def clear(interface_name, source_ip):
                 '-s', source_ip, '--syn', '-j',
                 'MARK', '--set-mark', IPTABLES_MARK
             ]()
-        except:
+        except Exception:
             break
 
 

--- a/src/tests/configure_synapse_test.py
+++ b/src/tests/configure_synapse_test.py
@@ -148,6 +148,8 @@ def test_generate_configuration(mock_get_current_location, mock_available_locati
                     'retries 2',
                     'timeout connect 2000ms',
                     'timeout server 3000ms',
+                    'acl to_be_tarpitted hdr_sub(X-Ctx-Tarpit) -i test_service',
+                    'reqtarpit . if to_be_tarpitted',
                 ],
                 'port': '1234',
                 'server_options': 'check port 6666 observe layer7 maxconn 50 maxqueue 10',
@@ -186,6 +188,10 @@ def test_generate_configuration(mock_get_current_location, mock_available_locati
             },
         },
     }
+
+    expected_configuration['haproxy']['defaults'].extend([
+        'timeout tarpit 60s',
+    ])
 
     assert actual_configuration == expected_configuration
     assert actual_configuration_reversed_advertise == expected_configuration
@@ -307,6 +313,8 @@ def test_generate_configuration_single_advertise(mock_get_current_location, mock
                     'retries 3',
                     'timeout connect 2000ms',
                     'timeout server 3000ms',
+                    'acl to_be_tarpitted hdr_sub(X-Ctx-Tarpit) -i test_service',
+                    'reqtarpit . if to_be_tarpitted',
                 ],
                 'port': '1234',
                 'server_options': 'check port 6666 observe layer7 maxconn 50 maxqueue 10',
@@ -314,6 +322,10 @@ def test_generate_configuration_single_advertise(mock_get_current_location, mock
             },
         },
     }
+
+    expected_configuration['haproxy']['defaults'].extend([
+        'timeout tarpit 60s',
+    ])
 
     assert actual_configuration == expected_configuration
     assert actual_configuration_default_advertise == expected_configuration
@@ -406,6 +418,8 @@ def test_generate_configuration_with_proxied_through(mock_get_current_location, 
                     'balance roundrobin',
                     'option httpchk GET /http/proxy_service/0/status',
                     'http-check send-state',
+                    'acl to_be_tarpitted hdr_sub(X-Ctx-Tarpit) -i proxy_service',
+                    'reqtarpit . if to_be_tarpitted',
                     'acl is_status_request path /status',
                     'reqadd X-Smartstack-Source:\\ proxy_service if !is_status_request',
                 ],
@@ -459,6 +473,8 @@ def test_generate_configuration_with_proxied_through(mock_get_current_location, 
                     'retries 2',
                     'timeout connect 2000ms',
                     'timeout server 3000ms',
+                    'acl to_be_tarpitted hdr_sub(X-Ctx-Tarpit) -i test_service',
+                    'reqtarpit . if to_be_tarpitted',
                 ],
                 'port': '1234',
                 'server_options': 'check port 6666 observe layer7 maxconn 50 maxqueue 10',
@@ -466,6 +482,10 @@ def test_generate_configuration_with_proxied_through(mock_get_current_location, 
             },
         },
     }
+
+    expected_configuration['haproxy']['defaults'].extend([
+        'timeout tarpit 60s',
+    ])
 
     assert actual_configuration == expected_configuration
 
@@ -546,6 +566,8 @@ def test_generate_configuration_with_nginx(mock_get_current_location, mock_avail
                     'retries 2',
                     'timeout connect 2000ms',
                     'timeout server 3000ms',
+                    'acl to_be_tarpitted hdr_sub(X-Ctx-Tarpit) -i test_service',
+                    'reqtarpit . if to_be_tarpitted',
                 ],
                 'port': '1234',
                 'server_options': 'check port 6666 observe layer7 maxconn 50 maxqueue 10',
@@ -608,6 +630,10 @@ def test_generate_configuration_with_nginx(mock_get_current_location, mock_avail
             'use_previous_backends': True
         },
     }
+
+    expected_configuration['haproxy']['defaults'].extend([
+        'timeout tarpit 60s',
+    ])
 
     assert actual_configuration == expected_configuration
 
@@ -688,6 +714,8 @@ def test_generate_configuration_only_nginx(mock_get_current_location, mock_avail
                     'retries 2',
                     'timeout connect 2000ms',
                     'timeout server 3000ms',
+                    'acl to_be_tarpitted hdr_sub(X-Ctx-Tarpit) -i test_service',
+                    'reqtarpit . if to_be_tarpitted',
                 ],
                 'bind_address': '/var/run/synapse/sockets/test_service.sock',
                 'server_options': 'check port 6666 observe layer7 maxconn 50 maxqueue 10',
@@ -750,6 +778,10 @@ def test_generate_configuration_only_nginx(mock_get_current_location, mock_avail
             'use_previous_backends': True
         },
     }
+
+    expected_configuration['haproxy']['defaults'].extend([
+        'timeout tarpit 60s',
+    ])
 
     assert actual_configuration == expected_configuration
 
@@ -835,6 +867,8 @@ def test_generate_configuration_with_logging_plugin(mock_get_current_location, m
                     'balance roundrobin',
                     'option httpchk GET /http/proxy_service/0/status',
                     'http-check send-state',
+                    'acl to_be_tarpitted hdr_sub(X-Ctx-Tarpit) -i proxy_service',
+                    'reqtarpit . if to_be_tarpitted',
                     'acl is_status_request path /status',
                     'reqadd X-Smartstack-Source:\\ proxy_service if !is_status_request',
                     'http-request lua.init_logging',
@@ -889,6 +923,8 @@ def test_generate_configuration_with_logging_plugin(mock_get_current_location, m
                     'retries 2',
                     'timeout connect 2000ms',
                     'timeout server 3000ms',
+                    'acl to_be_tarpitted hdr_sub(X-Ctx-Tarpit) -i test_service',
+                    'reqtarpit . if to_be_tarpitted',
                 ],
                 'port': '1234',
                 'server_options': 'check port 6666 observe layer7 maxconn 50 maxqueue 10',
@@ -1003,6 +1039,8 @@ def test_generate_configuration_with_multiple_plugins(mock_get_current_location,
                     'balance roundrobin',
                     'option httpchk GET /http/proxy_service/0/status',
                     'http-check send-state',
+                    'acl to_be_tarpitted hdr_sub(X-Ctx-Tarpit) -i proxy_service',
+                    'reqtarpit . if to_be_tarpitted',
                     'acl is_status_request path /status',
                     'reqadd X-Smartstack-Source:\\ proxy_service if !is_status_request',
                     'http-request lua.init_logging',
@@ -1059,6 +1097,8 @@ def test_generate_configuration_with_multiple_plugins(mock_get_current_location,
                     'retries 2',
                     'timeout connect 2000ms',
                     'timeout server 3000ms',
+                    'acl to_be_tarpitted hdr_sub(X-Ctx-Tarpit) -i test_service',
+                    'reqtarpit . if to_be_tarpitted',
                     'http-request lua.init_logging',
                     'http-request lua.log_provenance',
                 ],


### PR DESCRIPTION
# What?
Simply put, this is a fault-injection system at smartstack-level that will allow devs to simulate timeouts at various levels in a multi-service call. The point is, it can allow devs to trigger `RequestBudgetExceededException` on their own or dependent service/s.

# How this works?
Examples:
```
curl -I -v -H'X-Source-Id: spectre-test' -H'Host: internalapi' -H'X-Smartstack-Destination: yelp-main.internalapi' -H'X-Force-Master-Read: True' -H'X-Ctx-Tarpit: spectre.main' 'http://169.254.255.254:20678/category_yelp/?locale=en_US'
```
```
curl -I -v -H'X-Source-Id: spectre-test' -H'Host: internalapi' -H'X-Smartstack-Destination: yelp-main.internalapi' -H'X-Force-Master-Read: True' -H'X-Ctx-Tarpit: spectre.main, yelp-internalapi.main' 'http://169.254.255.254:20678/category_yelp/?locale=en_US'
```

# Testing done
Manually, on my devbox by turning off synapse cron runs and manually adding acl & tarpit rules to my `/var/run/synapse/haproxy.cfg` file.