### PR TITLE
Add backports.functools_lru_cache as a dependency for synapse-tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [v0.13.15](https://github.com/Yelp/synapse-tools/tree/v0.13.15) (2018-02-16)
+[Full Changelog](https://github.com/Yelp/synapse-tools/compare/v0.13.14...v0.13.15)
+
+**Merged pull requests:**
+
+- Add backports.functools_lru_cache to requirements [\#48](https://github.com/Yelp/synapse-tools/pull/48) ([avadhutp](https://github.com/avadhutp))
+
 ## [v0.13.14](https://github.com/Yelp/synapse-tools/tree/v0.13.14) (2018-02-14)
 [Full Changelog](https://github.com/Yelp/synapse-tools/compare/v0.13.13...v0.13.14)
 

--- a/dockerfiles/itest/itest/run_itest.sh
+++ b/dockerfiles/itest/itest/run_itest.sh
@@ -11,14 +11,6 @@ apt-get -y install -f
 echo "Testing that pyyaml uses optimized cyaml parsers if present"
 /opt/venvs/synapse-tools/bin/python -c 'import yaml; assert yaml.__with_libyaml__'
 
-if [ -f /etc/os-release ]; then
-    source /etc/os-release
-    if [[ $VERSION = *"Trusty"* ]]; then
-        echo "Trusty has issues with backports.functools_lru_cache; installing it"
-        /opt/venvs/synapse-tools/bin/pip install backports.functools_lru_cache
-    fi
-fi
-
 echo "Creating directory for unix sockets"
 mkdir -p /var/run/synapse/sockets
 

--- a/src/debian/changelog
+++ b/src/debian/changelog
@@ -1,3 +1,9 @@
+synapse-tools (0.13.15) lucid; urgency=low
+
+  * Fix requirements for deb packages
+
+ -- Avadhut Phatarpekar <avadhutp@yelp.com>  Fri, 16 Feb 2018 05:26:49 -0700
+
 synapse-tools (0.13.14) lucid; urgency=low
 
   * Enable fault-injection via X-Ctx-Tarpit header

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -7,3 +7,4 @@ pyroute2==0.3.4
 paasta-tools==0.56.0
 setuptools==33.1.1
 tox-pip-extensions==1.1.0
+backports.functools_lru_cache

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -7,4 +7,4 @@ pyroute2==0.3.4
 paasta-tools==0.56.0
 setuptools==33.1.1
 tox-pip-extensions==1.1.0
-backports.functools_lru_cache
+backports.functools_lru_cache==1.2.1

--- a/src/setup.py
+++ b/src/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='synapse-tools',
-    version='0.13.14',
+    version='0.13.15',
     provides=['synapse_tools'],
     author='John Billings',
     author_email='billings@yelp.com',


### PR DESCRIPTION
Trusty boxes don't have this dependency—I should've realized that when I changed the itest. Doh!

Basically, the package generated uses `pkg_resources` and that requires `backports.functools_lru_cache`.

```
---------------------------------------- Captured stderr ----------------------------------------
Traceback (most recent call last):
  File "/usr/bin/configure_synapse", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/opt/venvs/synapse-tools/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3019, in <module>
    @_call_aside
  File "/opt/venvs/synapse-tools/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3003, in _call_aside
    f(*args, **kwargs)
  File "/opt/venvs/synapse-tools/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3032, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/opt/venvs/synapse-tools/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 655, in _build_master
    ws.require(__requires__)
  File "/opt/venvs/synapse-tools/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 963, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/opt/venvs/synapse-tools/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 849, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'backports.functools_lru_cache>=1.2.1' distribution was not found and is required by arrow
```