### PR TITLE
Add X-Smartstack-Origin header for configured services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [v0.13.18](https://github.com/Yelp/synapse-tools/tree/v0.13.18) (2018-03-22)
+[Full Changelog](https://github.com/Yelp/synapse-tools/compare/v0.13.16...v0.13.18)
+
+**Merged pull requests:**
+
+- Enabled the source_required plugin [\#52](https://github.com/Yelp/synapse-tools/pull/52) ([avadhutp](https://github.com/avadhutp))
+
 ## [v0.13.16](https://github.com/Yelp/synapse-tools/tree/v0.13.16) (2018-02-27)
 [Full Changelog](https://github.com/Yelp/synapse-tools/compare/v0.13.15...v0.13.16)
 

--- a/dockerfiles/itest/itest/itest.py
+++ b/dockerfiles/itest/itest/itest.py
@@ -432,6 +432,19 @@ def test_logging_plugin(setup):
         check_plugin_logs(log_file, expected)
 
 
+def test_source_required_plugin(setup):
+    # Test plugins with only HAProxy
+    if 'nginx' not in setup and 'both' not in setup:
+
+        name = 'service_two.main'
+        data = SERVICES[name]
+        url = 'http://localhost:%d%s' % (data['proxy_port'], data['healthcheck_uri'])
+
+        request = urllib2.Request(url=url)
+        with contextlib.closing(
+            urllib2.urlopen(request, timeout=SOCKET_TIMEOUT)) as page:
+            assert page.info().dict['x-smartstack-origin'] == 'Test'
+
 # Helper for sending requests
 def send_requests(urls, headers=None):
     for url in urls:
@@ -449,6 +462,6 @@ def check_plugin_logs(log_file, expected):
             matching_logs = filter(lambda x: expected in x, logs)
             assert len(matching_logs) >= 1
 
-    except IOError as e:
+    except IOError:
         assert False
 

--- a/dockerfiles/itest/itest/yelpsoa-configs/service_three/smartstack.yaml
+++ b/dockerfiles/itest/itest/yelpsoa-configs/service_three/smartstack.yaml
@@ -27,6 +27,6 @@ logging:
   advertise:
   - habitat
   plugins:
-    logging: 
+    logging:
       enabled: True
       sample_rate: 1

--- a/dockerfiles/itest/itest/yelpsoa-configs/service_two/smartstack.yaml
+++ b/dockerfiles/itest/itest/yelpsoa-configs/service_two/smartstack.yaml
@@ -13,3 +13,6 @@ main:
     X-Mode: ro
   extra_healthcheck_headers:
     X-Mode: ro
+  plugins:
+    source_required:
+      enabled: True

--- a/dockerfiles/itest/service_two/test-server.py
+++ b/dockerfiles/itest/service_two/test-server.py
@@ -6,6 +6,12 @@ PORT = 1999
 
 class BlockingGetHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
 
+    def end_headers(self):
+        for header in self.headers.keys():
+            self.send_header(header, self.headers[header])
+
+        SimpleHTTPServer.SimpleHTTPRequestHandler.end_headers(self)
+
     def do_GET(self):
         logging.warning(self.headers)
         if 'x-mode' not in self.headers.keys():
@@ -13,12 +19,6 @@ class BlockingGetHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
         else:
             SimpleHTTPServer.SimpleHTTPRequestHandler.do_GET(self)
 
-
-class GetHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
-
-    def do_GET(self):
-        logging.warning(self.headers)
-        SimpleHTTPServer.SimpleHTTPRequestHandler.do_GET(self)
 
 httpd = SocketServer.TCPServer(("0.0.0.0", PORT), BlockingGetHandler)
 

--- a/src/debian/changelog
+++ b/src/debian/changelog
@@ -1,3 +1,10 @@
+synapse-tools (0.13.18) lucid; urgency=low
+
+  * Enable source_required plugin
+
+ -- Avadhut Phatarpekar <avadhutp@yelp.com>  Thy, 22 Mar 2018 02:00:23 -0700
+
+
 synapse-tools (0.13.16) lucid; urgency=low
 
   * Fix simultaneous builds on a single Jenkins Box

--- a/src/debian/changelog
+++ b/src/debian/changelog
@@ -2,7 +2,7 @@ synapse-tools (0.13.18) lucid; urgency=low
 
   * Enable source_required plugin
 
- -- Avadhut Phatarpekar <avadhutp@yelp.com>  Thy, 22 Mar 2018 02:00:23 -0700
+ -- Avadhut Phatarpekar <avadhutp@yelp.com>  Thu, 22 Mar 2018 02:00:23 -0700
 
 
 synapse-tools (0.13.16) lucid; urgency=low

--- a/src/setup.py
+++ b/src/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='synapse-tools',
-    version='0.13.18-rcAPOLLO-457',
+    version='0.13.18',
     provides=['synapse_tools'],
     author='John Billings',
     author_email='billings@yelp.com',

--- a/src/setup.py
+++ b/src/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='synapse-tools',
-    version='0.13.16',
+    version='0.13.17-rcAPOLLO-457',
     provides=['synapse_tools'],
     author='John Billings',
     author_email='billings@yelp.com',

--- a/src/setup.py
+++ b/src/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='synapse-tools',
-    version='0.13.17-rcAPOLLO-457',
+    version='0.13.18-rcAPOLLO-457',
     provides=['synapse_tools'],
     author='John Billings',
     author_email='billings@yelp.com',

--- a/src/synapse_tools/config_plugins/logging.py
+++ b/src/synapse_tools/config_plugins/logging.py
@@ -24,11 +24,8 @@ class Logging(HAProxyConfigPlugin):
 
         lua_dir = self.synapse_tools_config['lua_dir']
         lua_file = os.path.join(lua_dir, 'log_requests.lua')
-        map_dir = self.synapse_tools_config['map_dir']
-        map_file = os.path.join(map_dir, 'ip_to_service.map')
         opts = [
             'lua-load %s' % lua_file,
-            'setenv map_file %s' % map_file
         ]
         if 'sample_rate' in self.plugin_opts:
             sample_rate = str(self.plugin_opts['sample_rate'])

--- a/src/synapse_tools/config_plugins/registry.py
+++ b/src/synapse_tools/config_plugins/registry.py
@@ -4,10 +4,12 @@ from synapse_tools.config_plugins.fault_injection import FaultInjection
 from synapse_tools.config_plugins.logging import Logging
 from synapse_tools.config_plugins.path_based_routing import PathBasedRouting
 from synapse_tools.config_plugins.proxied_through import ProxiedThrough
+from synapse_tools.config_plugins.source_required import SourceRequired
 
 PLUGIN_REGISTRY = OrderedDict([
     ('fault_injection', FaultInjection),
     ('proxied_through', ProxiedThrough),
     ('logging', Logging),
-    ('path_based_routing', PathBasedRouting)
+    ('path_based_routing', PathBasedRouting),
+    ('source_required', SourceRequired),
 ])

--- a/src/synapse_tools/config_plugins/source_required.py
+++ b/src/synapse_tools/config_plugins/source_required.py
@@ -1,0 +1,37 @@
+import os
+from base import HAProxyConfigPlugin
+
+
+class SourceRequired(HAProxyConfigPlugin):
+    def __init__(self, service_name, service_info, synapse_tools_config):
+        super(SourceRequired, self).__init__(
+            service_name, service_info, synapse_tools_config
+        )
+
+        self.enabled = self.plugins.get('source_required', {}).get('enabled', False)
+
+    def global_options(self):
+        if not self.enabled:
+            return []
+
+        lua_dir = self.synapse_tools_config['lua_dir']
+        lua_file = os.path.join(lua_dir, 'add_source_header.lua')
+        opts = [
+            'lua-load %s' % lua_file,
+        ]
+
+        return opts
+
+    def defaults_options(self):
+        return []
+
+    def frontend_options(self):
+        return []
+
+    def backend_options(self):
+        if not self.enabled:
+            return []
+        return [
+            'http-request lua.init_add_source',
+            'http-request lua.add_source_header'
+        ]

--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -247,6 +247,13 @@ def _generate_haproxy_top_level(synapse_tools_config):
         }
     }
 
+    # Add the ip_to_svc.map as a haproxy top-level map_file environment variable
+    map_dir = synapse_tools_config['map_dir']
+    map_file = os.path.join(map_dir, 'ip_to_service.map')
+    top_level['global'].append(
+        'setenv map_file %s' % map_file,
+    )
+
     # Just for the migration to HAProxy 1.7, when SMTSTK-190 is done
     # always have this enabled and set the default to a sane default instead
     # of None

--- a/src/synapse_tools/lua_scripts/add_source_header.lua
+++ b/src/synapse_tools/lua_scripts/add_source_header.lua
@@ -11,8 +11,7 @@ core.register_action('init_add_source', {'tcp-req', 'http-req'}, init_add_source
 -- Add source header to the request
 function add_source_header(txn)
   -- Don't log if map doesn't exist or sampled out
-  if (map == nil) or (sample_rate == 0) or (math.random() > sample_rate) then
-    txn.http:req_add_header('X-Smartstack-Origin', 'No-MAP-File')
+  if (map == nil) then
     return
   end
 
@@ -21,10 +20,10 @@ function add_source_header(txn)
   if ip == nil then
     ip = 'nil'
   end
+  
   src_svc = map:lookup(ip)
-
   if src_svc == nil then
-    src_svc = ip
+    return
   end
 
   -- Add header

--- a/src/synapse_tools/lua_scripts/add_source_header.lua
+++ b/src/synapse_tools/lua_scripts/add_source_header.lua
@@ -1,0 +1,33 @@
+-- Loads map into Lua script
+function init_add_source(txn)
+  -- Load map if not yet loaded
+  if map == nil then
+    local map_file = txn.f:env('map_file')
+    map = Map.new(map_file, Map.str)
+  end
+end
+core.register_action('init_add_source', {'tcp-req', 'http-req'}, init_add_source)
+
+-- Add source header to the request
+function add_source_header(txn)
+  -- Don't log if map doesn't exist or sampled out
+  if (map == nil) or (sample_rate == 0) or (math.random() > sample_rate) then
+    txn.http:req_add_header('X-Smartstack-Origin', 'No-MAP-File')
+    return
+  end
+
+  -- Get source service
+  local ip = txn.f:src()
+  if ip == nil then
+    ip = 'nil'
+  end
+  src_svc = map:lookup(ip)
+
+  if src_svc == nil then
+    src_svc = ip
+  end
+
+  -- Add header
+  txn.http:req_add_header('X-Smartstack-Origin', src_svc)
+end
+core.register_action('add_source_header', {'tcp-req', 'http-req'}, add_source_header)


### PR DESCRIPTION
# What?
It enables a plugin called `source_required`. This, when enabled, will add a `X-Smartstack-Origin` header to the request. The value of this header will be the smartstack namespace of the calling service.

# Why?
As required by DSWG, it will enable Apollo to identify clients calling it (APOLLO-457).

# How's it being tested?
I've already modified unit tests and added itest to confirm this change. But I am also cutting an rc (which is why the change in `src/setup.py`) and installing it one (or more) devbox test the impact.