### PR TITLE
Reorder plugin directives to avoid warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [v0.13.19](https://github.com/Yelp/synapse-tools/tree/v0.13.19) (2018-04-16)
+[Full Changelog](https://github.com/Yelp/synapse-tools/compare/v0.13.18...v0.13.19)
+
+**Merged pull requests:**
+
+- Allow plugins to reorder their directives [\#53](https://github.com/Yelp/synapse-tools/pull/53) ([avadhutp](https://github.com/avadhutp))
+
 ## [v0.13.18](https://github.com/Yelp/synapse-tools/tree/v0.13.18) (2018-03-22)
 [Full Changelog](https://github.com/Yelp/synapse-tools/compare/v0.13.16...v0.13.18)
 

--- a/src/debian/changelog
+++ b/src/debian/changelog
@@ -1,3 +1,9 @@
+synapse-tools (0.13.19) lucid; urgency=low
+
+  * Allow plugins to reorder their directives
+
+ -- Avadhut Phatarpekar <avadhutp@yelp.com>  Thu, 16 Apr 2018 02:00:23 -0700
+
 synapse-tools (0.13.18) lucid; urgency=low
 
   * Enable source_required plugin

--- a/src/setup.py
+++ b/src/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='synapse-tools',
-    version='0.13.18',
+    version='0.13.19',
     provides=['synapse_tools'],
     author='John Billings',
     author_email='billings@yelp.com',

--- a/src/synapse_tools/config_plugins/base.py
+++ b/src/synapse_tools/config_plugins/base.py
@@ -16,6 +16,18 @@ class HAProxyConfigPlugin(object):
         self.service_info = service_info
         self.synapse_tools_config = synapse_tools_config
         self.plugins = service_info.get('plugins', {})
+        self.prepend_frontend_options = False
+        self.prepend_backend_options = False
+        self.prepend_global_options = False
+        self.prepend_defaults_options = False
+
+    def prepend_options(self, block_type):
+        """
+        Checks to see if the options to a particular HAProxy block
+        are to be prepended or appended. This is useful, for example, when
+        you want to order your http-request rules above any reqxxx rules.
+        """
+        return eval('self.prepend_{}_options'.format(block_type))
 
     @abc.abstractmethod
     def global_options(self):

--- a/src/synapse_tools/config_plugins/source_required.py
+++ b/src/synapse_tools/config_plugins/source_required.py
@@ -9,6 +9,7 @@ class SourceRequired(HAProxyConfigPlugin):
         )
 
         self.enabled = self.plugins.get('source_required', {}).get('enabled', False)
+        self.prepend_backend_options = True
 
     def global_options(self):
         if not self.enabled:

--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -467,16 +467,20 @@ def generate_configuration(synapse_tools_config, zookeeper_topology, services):
                 )
                 config_to_opts = [
                     (synapse_config['services'][service_name]['haproxy']['frontend'],
-                     plugin_instance.frontend_options()),
+                     plugin_instance.frontend_options(), plugin_instance.prepend_options('frontend')),
                     (synapse_config['services'][service_name]['haproxy']['backend'],
-                     plugin_instance.backend_options()),
+                     plugin_instance.backend_options(), plugin_instance.prepend_options('backend')),
                     (synapse_config['haproxy']['global'],
-                     plugin_instance.global_options()),
+                     plugin_instance.global_options(), plugin_instance.prepend_options('global')),
                     (synapse_config['haproxy']['defaults'],
-                     plugin_instance.defaults_options())
+                     plugin_instance.defaults_options(), plugin_instance.prepend_options('defaults'))
                 ]
-                for (config, opts) in config_to_opts:
-                    config.extend([x for x in opts if x not in config])
+                for (config, opts, prepend_options) in config_to_opts:
+                    options = [x for x in opts if x not in config]
+                    if prepend_options:
+                        config[0:0] += options
+                    else:
+                        config.extend(options)
 
             # TODO(jlynch|2017-08-15): move this to a plugin!
             # populate the ACLs to route to the service backends, this must

--- a/src/tests/configure_synapse_test.py
+++ b/src/tests/configure_synapse_test.py
@@ -853,6 +853,8 @@ def test_generate_configuration_with_source_required_plugin(mock_get_current_loc
                     'use_backend test_service if test_service_has_connslots',
                 ],
                 'backend': [
+                    'http-request lua.init_add_source',
+                    'http-request lua.add_source_header',
                     'balance roundrobin',
                     'reqidel ^X-Mode:.*',
                     'reqadd X-Mode:\ ro',
@@ -863,8 +865,6 @@ def test_generate_configuration_with_source_required_plugin(mock_get_current_loc
                     'timeout server 3000ms',
                     'acl to_be_tarpitted hdr_sub(X-Ctx-Tarpit) -i test_service',
                     'reqtarpit . if to_be_tarpitted',
-                    'http-request lua.init_add_source',
-                    'http-request lua.add_source_header',
                 ],
                 'port': '1234',
                 'server_options': 'check port 6666 observe layer7 maxconn 50 maxqueue 10',


### PR DESCRIPTION
`http-request` directives should not be placed before `reqxxx` directives. So, we give plugin authors the ability to prepend plugin directives if required.