### PR TITLE
Clean up old shutting-down nginx if we need to reload again.

### DIFF
--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -72,6 +72,7 @@ def set_defaults(config):
         # http://nginx.org/en/docs/control.html#upgrade
         # This is apparently how you gracefully reload the binary ...
         ('nginx_reload_cmd_fmt',
+            'if [ -f {nginx_pid_file_path}.oldbin ]; then kill -TERM $(cat {nginx_pid_file_path}) && sleep 2; fi ; '
             'kill -USR2 $(cat {nginx_pid_file_path}) && sleep 2 && '
             'kill -WINCH $(cat {nginx_pid_file_path}.oldbin) && '
             'kill -QUIT $(cat {nginx_pid_file_path}.oldbin)'),


### PR DESCRIPTION
Nginx will ignore SIGUSR2 if it's the new master process and its old master has not shut down yet.
This can cause problems: synapse will think it has reloaded nginx to e.g. add a new `server` directive, but nginx has not actually reloaded.

Internal ticket for more context: PAASTA-14538