### PR TITLE
Make the add_source_header lua plugin more resilient to the absence of the map file

### DIFF
--- a/dockerfiles/itest/itest/itest.py
+++ b/dockerfiles/itest/itest/itest.py
@@ -502,3 +502,29 @@ class TestGroupTwo(object):
             with contextlib.closing(
                 urllib2.urlopen(request, timeout=SOCKET_TIMEOUT)) as page:
                 assert page.info().dict['x-smartstack-origin'] == '0'
+
+
+class TestGroupThree(object):
+    @staticmethod
+    def pre_setup():
+        """Remove the map file to simulate what happens
+        on boxes (such as role::devbox) where the map file
+        is not generated at all.
+        """
+        map_file = '/var/run/synapse/maps/ip_to_service.map'
+        if os.path.isfile(map_file):
+            os.remove(map_file)
+
+    def test_source_required_plugin_without_map_entry(self, setup):
+        # Test plugins with only HAProxy
+        if 'nginx' not in setup and 'both' not in setup:
+
+            name = 'service_two.main'
+            data = SERVICES[name]
+            url = 'http://localhost:%d%s' % (data['proxy_port'], data['healthcheck_uri'])
+
+            # First, test with the service IP present in the map file
+            request = urllib2.Request(url=url, headers={'X-Smartstack-Origin': 'Spoof-Value'})
+            with contextlib.closing(
+                urllib2.urlopen(request, timeout=SOCKET_TIMEOUT)) as page:
+                assert page.info().dict['x-smartstack-origin'] == '0'

--- a/src/synapse_tools/lua_scripts/add_source_header.lua
+++ b/src/synapse_tools/lua_scripts/add_source_header.lua
@@ -2,6 +2,10 @@ map = {}
 map_file = nil
 refresh_interval = nil
 
+function log_error(err)
+  core.log(core.err, msg)
+end
+
 function refresh_map()
   map = Map.new(map_file, Map.str)
 end
@@ -9,7 +13,7 @@ end
 function init_vars()
   map_file = os.getenv('map_file')
   if map_file == nil then
-     core.log(core.err, 'map_file variable not set! This will cause authentication to fail for some requests.')
+     log_error('map_file variable not set! This will cause authentication to fail for some requests.')
    end
 
   refresh_interval = os.getenv('map_refresh_interval')
@@ -18,15 +22,15 @@ end
 -- This is run soon after haproxy parses haproxy.cfg. We will
 -- load the ip_to_svc map for the first time here.
 core.register_init(function()
-  init_vars()
-  refresh_map()
+  xpcall(init_vars, log_error)
+  xpcall(refresh_map, log_error)
 end)
 
 -- This will register a task, to refresh the ip_to_svc map,
 -- to run every 5 seconds
 core.register_task(function()
   while true do
-    refresh_map()
+    xpcall(refresh_map, log_error)
     core.sleep(refresh_interval)
   end
 end)

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -18,4 +18,4 @@ commands =
 [testenv:xenial]
 
 [flake8]
-ignore = E501
+ignore = E501, W605, W504


### PR DESCRIPTION
I have added new integration test that, without the fixes I've made in this commit, failed with the same error that we saw in the last go (https://fluffy.yelpcorp.com/i/4Q14JJHcMtPCQgqKhx7tQ4CtsbH5rMG0.html):
```
[ALERT] 295/063605 (89911) : lua init: runtime error: ...packages/synapse_tools/lua_scripts/add_source_header.lua:6: 'new': failed to open pattern file </var/run/synapse/maps/ip_to_service.map>..
```

Now this test passes.