### PR TITLE
Cleaning up the change that caused DAR-396:

### DIFF
--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -73,7 +73,6 @@ def set_defaults(config):
         # http://nginx.org/en/docs/control.html#upgrade
         # This is apparently how you gracefully reload the binary ...
         ('nginx_reload_cmd_fmt',
-            'if [ -f {nginx_pid_file_path}.oldbin ]; then kill -TERM $(cat {nginx_pid_file_path}) && sleep 2; fi ; '
             'kill -USR2 $(cat {nginx_pid_file_path}) && sleep 2 && '
             'kill -WINCH $(cat {nginx_pid_file_path}.oldbin) && '
             'kill -QUIT $(cat {nginx_pid_file_path}.oldbin)'),


### PR DESCRIPTION
We reverted the changed that rolled out 0.13.21 everywhere (https://reviewboard.yelpcorp.com/r/315864/). But we haven't really reverted the actual changes in this codebase. As a result, my changes include this DAR-inducing line and error out on 0.13.25.