### PR TITLE
Use deterministic hashing for server_order_seed in python3

### DIFF
--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -3,6 +3,7 @@ changed."""
 
 import copy
 import filecmp
+import hashlib
 import json
 import os
 import shutil
@@ -141,6 +142,13 @@ def _generate_nginx_top_level(synapse_tools_config):
     }
 
 
+def _generate_server_order_seed():
+    return int(
+        (hashlib.md5(socket.gethostname().encode('utf-8'))).hexdigest(),
+        16
+    )
+
+
 def _generate_haproxy_top_level(synapse_tools_config):
     haproxy_inter = synapse_tools_config['haproxy.defaults.inter']
     top_level = {
@@ -155,7 +163,7 @@ def _generate_haproxy_top_level(synapse_tools_config):
         'do_writes': True,
         'do_reloads': True,
         'do_socket': True,
-        'server_order_seed': hash(socket.gethostname()),
+        'server_order_seed': _generate_server_order_seed(),
 
         'global': [
             'daemon',


### PR DESCRIPTION
An alternative to the approach I used is to continue using `hash` and se the `PYTHONSEED` to 0 or somethingm. But in Python3, it is recommended to use one of the inbuilt hashlib algos to do deterministic hashing.