### PR TITLE
APOLLO-815: Add generate_container_ip_map

### DIFF
--- a/dockerfiles/itest/itest/itest.py
+++ b/dockerfiles/itest/itest/itest.py
@@ -192,6 +192,11 @@ class TestGroupOne(object):
         # is what we have for now
         subprocess.check_call(['synapse_qdisc_tool', '--help'])
 
+    def test_generate_map(self, setup):
+        # generate_container_ip_map needs docker client but since this
+        # runs inside docker itself, we need to add one separately.
+        subprocess.check_call(['generate_container_ip_map', '--help'])
+
 
     def test_synapse_services(self, setup):
         expected_services = [

--- a/src/debian/synapse-tools.links
+++ b/src/debian/synapse-tools.links
@@ -1,3 +1,4 @@
 opt/venvs/synapse-tools/bin/configure_synapse usr/bin/configure_synapse
+opt/venvs/synapse-tools/bin/generate_container_ip_map usr/bin/generate_container_ip_map
 opt/venvs/synapse-tools/bin/haproxy_synapse_reaper usr/bin/haproxy_synapse_reaper
 opt/venvs/synapse-tools/bin/synapse_qdisc_tool usr/bin/synapse_qdisc_tool

--- a/src/setup.py
+++ b/src/setup.py
@@ -29,6 +29,7 @@ setup(
     entry_points={
         'console_scripts': [
             'configure_synapse=synapse_tools.configure_synapse:main',
+            'generate_container_ip_map=synapse_tools.generate_container_ip_map:main',
             'haproxy_synapse_reaper=synapse_tools.haproxy_synapse_reaper:main',
             'synapse_qdisc_tool=synapse_tools.haproxy.qdisc_tool:main',
         ],

--- a/src/synapse_tools/generate_container_ip_map.py
+++ b/src/synapse_tools/generate_container_ip_map.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+import argparse
+import os
+import socket
+
+from paasta_tools.utils import atomic_file_write
+from paasta_tools.utils import get_docker_client
+
+HAPROXY_STATS_SOCKET = '/var/run/synapse/haproxy.sock'
+
+
+def get_prev_file_contents(filename):
+    if os.path.isfile(filename):
+        with open(filename, 'r') as fp:
+            prev_lines = [
+                # Remove any empty strings, since split could leave empty
+                # strings if there is any extra whitespace in the file
+                list(filter(None, line.strip().split(' ')))
+                for line
+                in fp.readlines()
+            ]
+            return {line[0]: line[1] for line in prev_lines}
+    return {}
+
+
+def extract_taskid_and_ip(docker_client):
+    service_ips_and_ids = []
+    for container in docker_client.containers():
+        networks = container['NetworkSettings']['Networks']
+        labels = container['Labels']
+
+        # Only add containers that are using bridged networking and are
+        # running as Mesos tasks
+        if 'bridge' in networks:
+            ip_addr = networks['bridge']['IPAddress']
+            if 'MESOS_TASK_ID' in labels:
+                task_id = labels['MESOS_TASK_ID']
+                service_ips_and_ids.append((ip_addr, task_id))
+            # For compatibility with tron/batch services.
+            elif 'paasta_instance' in labels and 'paasta_service' in labels:
+                task_id = '{}.{}'.format(
+                    labels['paasta_service'],
+                    labels['paasta_instance'],
+                )
+                # For compatibility with MESOS_TASK_ID format.
+                task_id = task_id.replace('_', '--')
+                service_ips_and_ids.append((ip_addr, task_id))
+    return service_ips_and_ids
+
+
+def send_to_haproxy(command, timeout):
+    s = socket.socket(socket.AF_UNIX)
+    s.settimeout(timeout)
+    s.connect(HAPROXY_STATS_SOCKET)
+    s.send((command + '\n').encode())
+    s.close()
+
+
+def update_haproxy_mapping(
+    ip_addr,
+    task_id,
+    prev_ip_to_task_id,
+    filename,
+    timeout,
+):
+    # Check if this IP was in the file previously, if so, we want
+    # to send an update to the HAProxy map instead of adding a new
+    # entry (new additions to the map don't overwrite old entries
+    # and instead create duplicate keys with different values).
+    if ip_addr in prev_ip_to_task_id:
+        if prev_ip_to_task_id[ip_addr] != task_id:
+            method = 'set'
+        else:
+            method = None
+    else:
+        # The IP was not added previously, add it as a new entry
+        method = 'add'
+
+    if method:
+        send_to_haproxy('{} map {} {} {}'.format(
+            method,
+            filename,
+            ip_addr,
+            task_id,
+        ), timeout)
+
+
+def remove_stopped_container_entries(prev_ips, curr_ips, filename, timeout):
+    for ip in prev_ips:
+        if ip not in curr_ips:
+            send_to_haproxy('del map {} {}'.format(
+                filename,
+                ip,
+            ), timeout)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            'Script to dump a HAProxy map between container IPs and task IDs.'
+        ),
+    )
+    parser.add_argument(
+        '--update-haproxy',
+        '-U',
+        action='store_true',
+        help='Whether to update haproxy for map updates',
+    )
+    parser.add_argument(
+        '--haproxy-timeout',
+        '-T',
+        type=int,
+        default=1,
+        help='Timeout for haproxy socket connections',
+    )
+    parser.add_argument(
+        'map_file',
+        nargs='?',
+        default='/var/run/synapse/maps/ip_to_service.map',
+        help='Where to write the output map file',
+    )
+    args = parser.parse_args()
+
+    if args.update_haproxy:
+        prev_ip_to_task_id = get_prev_file_contents(args.map_file)
+
+    new_lines = []
+    ip_addrs = []
+    service_ips_and_ids = extract_taskid_and_ip(get_docker_client())
+
+    for ip_addr, task_id in service_ips_and_ids:
+        ip_addrs.append(ip_addr)
+        if args.update_haproxy:
+            update_haproxy_mapping(
+                ip_addr,
+                task_id,
+                prev_ip_to_task_id,
+                args.map_file,
+                args.haproxy_timeout,
+            )
+        new_lines.append('{ip_addr} {task_id}'.format(
+            ip_addr=ip_addr,
+            task_id=task_id,
+        )
+        )
+
+    if args.update_haproxy:
+        remove_stopped_container_entries(
+            prev_ip_to_task_id.keys(),
+            ip_addrs,
+            args.map_file,
+            args.haproxy_timeout,
+        )
+
+    # Replace the file contents with the new map
+    with atomic_file_write(args.map_file) as fp:
+        fp.write('\n'.join(new_lines))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is
https://github.com/Yelp/paasta/blob/master/paasta_tools/contrib/get_containers_and_ips.py
moved to synapse-tools.

This is to ease the deployment of changes by grouping it with lua_scripts
deployment. It will also help with integration testing with the lua scripts and haproxy.

The script has been renamed to reflect its true purpose, to generate_container_ip_map.

Also, updated the generate_container_ip_map to add timeout argument.