### PR TITLE
Add error log option

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -3,7 +3,7 @@ dulwich==0.19.5
 environment_tools==1.1.0
 plumbum==1.6.0
 psutil==2.1.1
-PyYAML==4.2b1
+PyYAML==3.11
 pyroute2==0.3.4
 paasta-tools==0.81.26
 setuptools==37.0.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -3,7 +3,7 @@ dulwich==0.19.5
 environment_tools==1.1.0
 plumbum==1.6.0
 psutil==2.1.1
-PyYAML==3.11
+PyYAML==4.2b1
 pyroute2==0.3.4
 paasta-tools==0.81.26
 setuptools==37.0.0

--- a/src/synapse_tools/config_plugins/base.py
+++ b/src/synapse_tools/config_plugins/base.py
@@ -88,6 +88,8 @@ SynapseToolsConfig = TypedDict(
         'nginx_reload_cmd_fmt': str,
         'nginx_start_cmd_fmt': str,
         'nginx_restart_interval_s': int,
+        'nginx_log_error_target': str,
+        'nginx_log_error_level': str,
     },
 )
 

--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -54,6 +54,8 @@ class NginxTopLevelConfig(TypedDict):
     restart_interval: int
     restart_jitter: float
     listen_address: str
+    log_error_target: str
+    log_error_level: str
 
 
 HAProxyTopLevelConfigExtraSections = TypedDict(
@@ -202,6 +204,8 @@ def set_defaults(
         # (aka services) This should be relatively rare so we crank up the
         # restart_interval to limit memory consumption.
         ('nginx_restart_interval_s', 600),
+        ('nginx_log_error_target', '/dev/null'),
+        ('nginx_log_error_level', 'crit'),
     ]
 
     for k, v in defaults:
@@ -231,7 +235,10 @@ def _generate_nginx_top_level(
                     int(synapse_tools_config['maximum_connections']) * 4
                 ),
                 'pid {0}'.format(synapse_tools_config['nginx_pid_file_path']),
-                'error_log /dev/null crit',
+                'error_log {0} {1}'.format(
+                    synapse_tools_config['nginx_log_error_target'],
+                    synapse_tools_config['nginx_log_error_level']
+                ),
             ],
             'stream': [
                 'tcp_nodelay on'

--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -54,8 +54,6 @@ class NginxTopLevelConfig(TypedDict):
     restart_interval: int
     restart_jitter: float
     listen_address: str
-    log_error_target: str
-    log_error_level: str
 
 
 HAProxyTopLevelConfigExtraSections = TypedDict(


### PR DESCRIPTION
We run nginx without any kind of error logging. This could potentially
    hide issues. I'm investigating a case where requests are not making it
    to haproxy so enabling the logs is a first good step here.
    This change is a noop as I keep the same default values


I didn't bump pyyaml because the version that contains the fix for the security issue mentioned by github is not stable yet

See https://github.com/yaml/pyyaml/issues/243