### PR TITLE
Ignore mypy when deploying

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,4 @@ deploy:
     on:
       tags: true
       repo: Yelp/synapse-tools
+      condition: $MAKE_TARGET =~ ^itest_


### PR DESCRIPTION
When I tagged v0.13.30 and pushed it, travis failed when building the mypy target: [https://travis-ci.org/Yelp/synapse-tools/builds/523617116](https://travis-ci.org/Yelp/synapse-tools/builds/523617116)

There shouldn't be anything to deploy for mypy, so let's make travis ignore it.

I tested the conditional using `travis-conditions`:
```
$ MAKE_TARGET=itest_xenial
$ travis-conditions eval "$MAKE_TARGET =~ ^itest_" --data '{}'
true
$ MAKE_TARGET=itest_trusty
$ travis-conditions eval "$MAKE_TARGET =~ ^itest_" --data '{}'
true
$ MAKE_TARGET=mypy
$ travis-conditions eval "$MAKE_TARGET =~ ^itest_" --data '{}'
false
```