### PR TITLE
Build for bionic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,15 @@ __pycache__
 .pip/
 .tox/
 dist/
+synapse-tools*.buildinfo
 synapse-tools*.changes
+synapse-tools*.ddeb
 synapse-tools*.dsc
 synapse-tools*.tar.gz
 src/.eggs
+src/.pytest_cache/
 src/build
+src/debian/.debhelper
 src/debian/debhelper-build-stamp
 src/debian/files
 src/debian/synapse-tools
@@ -17,6 +21,7 @@ src/debian/synapse-tools.substvars
 src/synapse_tools.egg-info
 dockerfiles/itest/itest_trusty/
 dockerfiles/itest/itest_xenial/
+dockerfiles/itest/itest_bionic/
 src/debian/synapse-tools.postinst.debhelper
 src/.cache/
 bintray.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
-  # Don't build for lucid because it is ancient and doesn't even have Python 2.7
   - MAKE_TARGET=itest_trusty
   - MAKE_TARGET=itest_xenial
+  - MAKE_TARGET=itest_bionic
   - MAKE_TARGET=mypy
 branch:
   only:

--- a/dockerfiles/bionic/Dockerfile
+++ b/dockerfiles/bionic/Dockerfile
@@ -1,5 +1,4 @@
 FROM ubuntu:bionic
-MAINTAINER John Billings <billings@yelp.com>
 
 RUN apt-get update && apt-get -y install \
     debhelper \

--- a/dockerfiles/bionic/Dockerfile
+++ b/dockerfiles/bionic/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:bionic
+MAINTAINER John Billings <billings@yelp.com>
+
+RUN apt-get update && apt-get -y install \
+    debhelper \
+    dh-virtualenv \
+    dpkg-dev \
+    libyaml-dev \
+    libcurl4-openssl-dev \
+    python3.6-dev \
+    python-tox \
+    python-setuptools \
+    libffi-dev \
+    libssl-dev \
+    build-essential \
+    protobuf-compiler \
+    gdebi-core \
+    wget
+
+WORKDIR /work

--- a/dockerfiles/bionic/docker-compose.yml
+++ b/dockerfiles/bionic/docker-compose.yml
@@ -1,0 +1,5 @@
+bionic:
+  build: ../../dockerfiles/bionic
+  command: bash -c "cd src && tox -ebionic && dpkg-buildpackage -d -uc -us && mv ../*.deb ../dist/"
+  volumes:
+   - ../..:/work

--- a/dockerfiles/itest/docker-compose-bionic.yml
+++ b/dockerfiles/itest/docker-compose-bionic.yml
@@ -1,0 +1,28 @@
+itest:
+  build: ../../dockerfiles/itest/itest_bionic
+  hostname: itesthost.itestdomain
+  volumes:
+   - ../..:/work
+  environment:
+    CONTAINER_PREFIX: bionic
+  links:
+   - bionicservicetwo
+   - bionicservicethree
+   - bionicservicethreechaos
+   - bionicserviceone
+   - bioniczookeeper
+
+bionicservicethree:
+  build: ../../dockerfiles/itest/service_three
+
+bionicserviceone:
+  build: ../../dockerfiles/itest/service_one
+
+bioniczookeeper:
+  build: ../../dockerfiles/itest/zookeeper
+
+bionicservicethreechaos:
+  build: ../../dockerfiles/itest/service_three
+
+bionicservicetwo:
+  build: ../../dockerfiles/itest/service_two

--- a/dockerfiles/itest/itest/Dockerfile.bionic
+++ b/dockerfiles/itest/itest/Dockerfile.bionic
@@ -1,5 +1,4 @@
 FROM ubuntu:bionic
-MAINTAINER John Billings <billings@yelp.com>
 
 # Need Python 3.6
 RUN apt-get update > /dev/null && \

--- a/dockerfiles/itest/itest/Dockerfile.bionic
+++ b/dockerfiles/itest/itest/Dockerfile.bionic
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:bionic
 MAINTAINER John Billings <billings@yelp.com>
 
 # Need Python 3.6
@@ -15,38 +15,30 @@ RUN apt-get update && apt-get -y install \
     python-pycurl \
     python-kazoo \
     python-zope.interface \
-    ruby1.9.1 \
-    ruby1.9.1-dev \
-    rubygems1.9.1 \
+    ruby \
+    ruby-dev \
     libxml2 \
     libxml2-dev \
     libxslt-dev \
-    libssl-dev \
     build-essential \
-    zlib1g-dev
+    zlib1g-dev \
+    nginx \
+    liblua5.3-dev \
+    libssl-dev \
+    rsyslog
 
-# Lua 5.3 for scripting with HAProxy
-WORKDIR /
-ADD http://www.lua.org/ftp/lua-5.3.1.tar.gz /lua-5.3.1.tar.gz
-RUN tar -axvf /lua-5.3.1.tar.gz
-WORKDIR /lua-5.3.1
-RUN pwd
-RUN make generic
-RUN make install INSTALL_TOP=/usr/bin/lua
-
-# Ubuntu trusty nginx and haproxy are ancient, grab newer ones
+# HAProxy configured with Lua scripting
 WORKDIR /
 ADD http://www.haproxy.org/download/1.7/src/haproxy-1.7.8.tar.gz /haproxy.tar.gz
 RUN tar -axvf /haproxy.tar.gz
 WORKDIR /haproxy-1.7.8
-RUN pwd
-RUN make TARGET=linux26 -j 4 \
+RUN make TARGET=linux26 \
     USE_LUA=1 \
-    LUA_LIB=/usr/bin/lua/lib \
-    LUA_INC=/usr/bin/lua/include \
+    LUA_LIB=/usr/lib/x86_64-linux-gnu \
+    LUA_INC=/usr/include/lua5.3 \
     && mv haproxy /usr/bin/haproxy-synapse
 
-# Nginx
+# Nginx (the upstream nginx switches to using a dynamic stream module)
 WORKDIR /
 ADD https://nginx.org/download/nginx-1.13.3.tar.gz /nginx.tar.gz
 RUN tar -axvf /nginx.tar.gz
@@ -81,7 +73,7 @@ ADD synapse-tools-nginx.conf.json /etc/synapse/synapse-tools-nginx.conf.json
 
 # Zookeeper discovery
 RUN mkdir -p /nail/etc/zookeeper_discovery/infrastructure
-ADD zookeeper_discovery/infrastructure/local.yaml.trusty /nail/etc/zookeeper_discovery/infrastructure/local.yaml
+ADD zookeeper_discovery/infrastructure/local.yaml.bionic /nail/etc/zookeeper_discovery/infrastructure/local.yaml
 
 ADD yelpsoa-configs /nail/etc/services
 ADD habitat /nail/etc/habitat

--- a/dockerfiles/itest/itest/Dockerfile.trusty
+++ b/dockerfiles/itest/itest/Dockerfile.trusty
@@ -1,5 +1,4 @@
 FROM ubuntu:14.04
-MAINTAINER John Billings <billings@yelp.com>
 
 # Need Python 3.6
 RUN apt-get update > /dev/null && \

--- a/dockerfiles/itest/itest/Dockerfile.xenial
+++ b/dockerfiles/itest/itest/Dockerfile.xenial
@@ -1,5 +1,4 @@
 FROM ubuntu:xenial
-MAINTAINER John Billings <billings@yelp.com>
 
 # Need Python 3.6
 RUN apt-get update > /dev/null && \

--- a/dockerfiles/itest/itest/zookeeper_discovery/infrastructure/local.yaml.bionic
+++ b/dockerfiles/itest/itest/zookeeper_discovery/infrastructure/local.yaml.bionic
@@ -1,0 +1,1 @@
+[['bioniczookeeper_1', 2181]]

--- a/dockerfiles/itest/service_one/Dockerfile
+++ b/dockerfiles/itest/service_one/Dockerfile
@@ -1,5 +1,4 @@
 FROM ubuntu:14.04
-MAINTAINER John Billings <billings@yelp.com>
 RUN apt-get update && apt-get install -y git python python-setuptools python-pip
 RUN git clone --branch yelp https://github.com/Yelp/hacheck
 RUN cd /hacheck && python setup.py install

--- a/dockerfiles/itest/service_three/Dockerfile
+++ b/dockerfiles/itest/service_three/Dockerfile
@@ -1,5 +1,4 @@
 FROM ubuntu:14.04
-MAINTAINER John Billings <billings@yelp.com>
 RUN apt-get update && apt-get install -y git python python-setuptools python-pip
 RUN git clone --branch yelp https://github.com/Yelp/hacheck
 RUN cd /hacheck && python setup.py install

--- a/dockerfiles/itest/service_two/Dockerfile
+++ b/dockerfiles/itest/service_two/Dockerfile
@@ -1,5 +1,4 @@
 FROM ubuntu:14.04
-MAINTAINER John Billings <billings@yelp.com>
 RUN apt-get update && apt-get install -y git python python-setuptools python-pip
 RUN git clone --branch yelp https://github.com/Yelp/hacheck
 RUN cd /hacheck && python setup.py install

--- a/dockerfiles/itest/zookeeper/Dockerfile
+++ b/dockerfiles/itest/zookeeper/Dockerfile
@@ -1,5 +1,4 @@
 FROM ubuntu:14.04
-MAINTAINER John Billings <billings@yelp.com>
 
 RUN apt-get update
 RUN apt-get -y install zookeeper

--- a/dockerfiles/trusty/Dockerfile
+++ b/dockerfiles/trusty/Dockerfile
@@ -1,5 +1,4 @@
 FROM ubuntu:14.04
-MAINTAINER John Billings <billings@yelp.com>
 
 RUN rm -f /etc/apt/sources.list.d/proposed.list
 

--- a/dockerfiles/xenial/Dockerfile
+++ b/dockerfiles/xenial/Dockerfile
@@ -1,5 +1,4 @@
 FROM ubuntu:xenial
-MAINTAINER John Billings <billings@yelp.com>
 
 # Need Python 3.6
 RUN apt-get update > /dev/null && \

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -17,6 +17,8 @@ commands =
 
 [testenv:xenial]
 
+[testenv:bionic]
+
 [flake8]
 ignore = E501, W605, W504
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,15 @@ commands =
     docker-compose stop
     docker-compose rm --force
 
+[testenv:package_bionic]
+setenv =
+    COMPOSE_FILE = dockerfiles/bionic/docker-compose.yml
+commands =
+    docker-compose --verbose build
+    docker-compose run bionic
+    docker-compose stop
+    docker-compose rm --force
+
 [testenv:fix_permissions]
 whitelist_externals = /bin/bash
 setenv =
@@ -46,6 +55,15 @@ commands =
 [testenv:itest_xenial]
 setenv =
     COMPOSE_FILE = dockerfiles/itest/docker-compose-xenial.yml
+commands =
+    docker-compose --verbose build
+    docker-compose run itest
+    docker-compose stop
+    docker-compose rm --force
+
+[testenv:itest_bionic]
+setenv =
+    COMPOSE_FILE = dockerfiles/itest/docker-compose-bionic.yml
 commands =
     docker-compose --verbose build
     docker-compose run itest


### PR DESCRIPTION
This is SMTSTK-228, but essentially I'm just adding the itests, dockerfiles, and general setup for building and testing this with bionic. None of the actual package code changes, just the testing infrastructure.

I also upgraded the nginx version used for trusty from `1.11.10` to `1.13.3` to match bionic (and the version we are using), and had to custom-built the nginx version in bionic to avoid an issue where the upstream nginx version uses `--with-stream=dynamic` but we use `--with-stream` meaning the config would be different between the itest and reality (and just for bionic too), so I thought building nginx in the container was the easiest and most consistent way out of that one.