### PR TITLE
Remove trusty from tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 env:
-  - MAKE_TARGET=itest_trusty
   - MAKE_TARGET=itest_xenial
   - MAKE_TARGET=itest_bionic
   - MAKE_TARGET=mypy


### PR DESCRIPTION
We don't use Trusty, so let's remove it.