### PR TITLE
Fix tests by downgrading pip to 19.3.1

### DIFF
--- a/src/debian/rules
+++ b/src/debian/rules
@@ -22,4 +22,5 @@ override_dh_auto_test:
 override_dh_virtualenv:
 	dh_virtualenv `host pypi.yelpcorp.com >/dev/null 2>&1 && echo '--extra-index-url https://pypi.yelpcorp.com/simple'` \
 	--python=/usr/bin/python3.6 --preinstall no-manylinux1 \
+	--preinstall pip==19.3.1 \
 	--preinstall pip-custom-platform --pip-tool pip-custom-platform


### PR DESCRIPTION
Tests are failing with errors like
```
Traceback (most recent call last):
  File
  "/work/src/debian/synapse-tools/opt/venvs/synapse-tools/lib/python3.6/site-packages/pip_custom_platform/_main.py",
  line 15, in <module>
      from pip._internal.commands import get_summaries
      ImportError: cannot import name 'get_summaries'
```
because of a changed `_internals` in `pip==20.1b1`.

Let's fix that by using `pip==19.3.1`.

# Note
`itest_trusty` is broken because of python2, broken versions of several core python libraries, and several other things.
Since we're moving from Trusty, I'm not going to fix it, but going to disable it in the following PR.