### PR TITLE
Remove itest_trusty from Travis tests list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 env:
-  - MAKE_TARGET=itest_trusty
   - MAKE_TARGET=itest_xenial
   - MAKE_TARGET=itest_bionic
   - MAKE_TARGET=mypy


### PR DESCRIPTION
It's broken and we shouldn't waste our time on fixing it.