### PR TITLE
Ensure internal yelp builds use internal pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 env:
-  - MAKE_TARGET=itest_xenial
-  - MAKE_TARGET=itest_bionic
-  - MAKE_TARGET=mypy
+  global:
+    - PIP_INDEX_URL=https://pypi.python.org/simple
+  jobs:
+    - MAKE_TARGET=itest_xenial
+    - MAKE_TARGET=itest_bionic
+    - MAKE_TARGET=mypy
 branch:
   only:
     - master

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+export PIP_INDEX_URL ?= https://pypi.yelpcorp.com/simple
 DATE := $(shell date +'%Y-%m-%d')
 SYNAPSETOOLSVERSION := $(shell sed 's/.*(\(.*\)).*/\1/;q' src/debian/changelog)
 

--- a/dockerfiles/bionic/Dockerfile
+++ b/dockerfiles/bionic/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:bionic
 
+ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
+ENV PIP_INDEX_URL=$PIP_INDEX_URL
+
 RUN apt-get update && apt-get -y install \
     debhelper \
     dh-virtualenv \
@@ -8,6 +11,7 @@ RUN apt-get update && apt-get -y install \
     libcurl4-openssl-dev \
     python3.6-dev \
     python-tox \
+    python3-pip \
     python-setuptools \
     libffi-dev \
     libssl-dev \
@@ -15,5 +19,9 @@ RUN apt-get update && apt-get -y install \
     protobuf-compiler \
     gdebi-core \
     wget
+
+# When using internal pypi on older virtualenvs they
+# fail looking for pkg-resources?!
+RUN pip3 install virtualenv==16.0.0
 
 WORKDIR /work

--- a/dockerfiles/bionic/docker-compose.yml
+++ b/dockerfiles/bionic/docker-compose.yml
@@ -1,5 +1,7 @@
-bionic:
-  build: ../../dockerfiles/bionic
-  command: bash -c "cd src && tox -ebionic && dpkg-buildpackage -d -uc -us && mv ../*.deb ../dist/"
-  volumes:
-   - ../..:/work
+version: '2.4'
+services:
+  bionic:
+    build: ../../dockerfiles/bionic
+    command: bash -c "cd src && tox -ebionic && dpkg-buildpackage -d -uc -us && mv ../*.deb ../dist/"
+    volumes:
+     - ../..:/work

--- a/dockerfiles/itest/docker-compose-bionic.yml
+++ b/dockerfiles/itest/docker-compose-bionic.yml
@@ -1,32 +1,34 @@
-itest:
-  build: ../../dockerfiles/itest/itest_bionic
-  hostname: itesthost.itestdomain
-  volumes:
-   - ../..:/work
-  environment:
-    CONTAINER_PREFIX: bionic
-  links:
-   - bionicservicetwo
-   - bionicservicethree
-   - bionicservicethreechaos
-   - bionicserviceone
-   - bioniczookeeper
-   - bionicservicethree_endpoint_timeout
+version: '2.4'
+services:
+  itest:
+    build: ../../dockerfiles/itest/itest_bionic
+    hostname: itesthost.itestdomain
+    volumes:
+     - ../..:/work
+    environment:
+      CONTAINER_PREFIX: bionic
+    links:
+     - bionicservicetwo
+     - bionicservicethree
+     - bionicservicethreechaos
+     - bionicserviceone
+     - bioniczookeeper
+     - bionicservicethree_endpoint_timeout
 
-bionicservicethree_endpoint_timeout:
-  build: ../../dockerfiles/itest/service_three
+  bionicservicethree_endpoint_timeout:
+    build: ../../dockerfiles/itest/service_three
 
-bionicservicethree:
-  build: ../../dockerfiles/itest/service_three
+  bionicservicethree:
+    build: ../../dockerfiles/itest/service_three
 
-bionicserviceone:
-  build: ../../dockerfiles/itest/service_one
+  bionicserviceone:
+    build: ../../dockerfiles/itest/service_one
 
-bioniczookeeper:
-  build: ../../dockerfiles/itest/zookeeper
+  bioniczookeeper:
+    build: ../../dockerfiles/itest/zookeeper
 
-bionicservicethreechaos:
-  build: ../../dockerfiles/itest/service_three
+  bionicservicethreechaos:
+    build: ../../dockerfiles/itest/service_three
 
-bionicservicetwo:
-  build: ../../dockerfiles/itest/service_two
+  bionicservicetwo:
+    build: ../../dockerfiles/itest/service_two

--- a/dockerfiles/itest/docker-compose-trusty.yml
+++ b/dockerfiles/itest/docker-compose-trusty.yml
@@ -1,32 +1,34 @@
-itest:
-  build: ../../dockerfiles/itest/itest_trusty
-  hostname: itesthost.itestdomain
-  volumes:
-   - ../..:/work
-  environment:
-    CONTAINER_PREFIX: trusty
-  links:
-   - trustyservicetwo
-   - trustyservicethree
-   - trustyservicethreechaos
-   - trustyserviceone
-   - trustyzookeeper
-   - trustyservicethree_endpoint_timeout
+version: '2.4'
+services:
+  itest:
+    build: ../../dockerfiles/itest/itest_trusty
+    hostname: itesthost.itestdomain
+    volumes:
+     - ../..:/work
+    environment:
+      CONTAINER_PREFIX: trusty
+    links:
+     - trustyservicetwo
+     - trustyservicethree
+     - trustyservicethreechaos
+     - trustyserviceone
+     - trustyzookeeper
+     - trustyservicethree_endpoint_timeout
 
-trustyservicethree_endpoint_timeout:
-  build: ../../dockerfiles/itest/service_three
+  trustyservicethree_endpoint_timeout:
+    build: ../../dockerfiles/itest/service_three
 
-trustyservicethree:
-  build: ../../dockerfiles/itest/service_three
+  trustyservicethree:
+    build: ../../dockerfiles/itest/service_three
 
-trustyserviceone:
-  build: ../../dockerfiles/itest/service_one
+  trustyserviceone:
+    build: ../../dockerfiles/itest/service_one
 
-trustyzookeeper:
-  build: ../../dockerfiles/itest/zookeeper
+  trustyzookeeper:
+    build: ../../dockerfiles/itest/zookeeper
 
-trustyservicethreechaos:
-  build: ../../dockerfiles/itest/service_three
+  trustyservicethreechaos:
+    build: ../../dockerfiles/itest/service_three
 
-trustyservicetwo:
-  build: ../../dockerfiles/itest/service_two
+  trustyservicetwo:
+    build: ../../dockerfiles/itest/service_two

--- a/dockerfiles/itest/docker-compose-xenial.yml
+++ b/dockerfiles/itest/docker-compose-xenial.yml
@@ -1,32 +1,34 @@
-itest:
-  build: ../../dockerfiles/itest/itest_xenial
-  hostname: itesthost.itestdomain
-  volumes:
-   - ../..:/work
-  environment:
-    CONTAINER_PREFIX: xenial
-  links:
-   - xenialservicetwo
-   - xenialservicethree
-   - xenialservicethreechaos
-   - xenialserviceone
-   - xenialzookeeper
-   - xenialservicethree_endpoint_timeout
+version: '2.4'
+services:
+  itest:
+    build: ../../dockerfiles/itest/itest_xenial
+    hostname: itesthost.itestdomain
+    volumes:
+     - ../..:/work
+    environment:
+      CONTAINER_PREFIX: xenial
+    links:
+     - xenialservicetwo
+     - xenialservicethree
+     - xenialservicethreechaos
+     - xenialserviceone
+     - xenialzookeeper
+     - xenialservicethree_endpoint_timeout
 
-xenialservicethree_endpoint_timeout:
-  build: ../../dockerfiles/itest/service_three
+  xenialservicethree_endpoint_timeout:
+    build: ../../dockerfiles/itest/service_three
 
-xenialservicethree:
-  build: ../../dockerfiles/itest/service_three
+  xenialservicethree:
+    build: ../../dockerfiles/itest/service_three
 
-xenialserviceone:
-  build: ../../dockerfiles/itest/service_one
+  xenialserviceone:
+    build: ../../dockerfiles/itest/service_one
 
-xenialzookeeper:
-  build: ../../dockerfiles/itest/zookeeper
+  xenialzookeeper:
+    build: ../../dockerfiles/itest/zookeeper
 
-xenialservicethreechaos:
-  build: ../../dockerfiles/itest/service_three
+  xenialservicethreechaos:
+    build: ../../dockerfiles/itest/service_three
 
-xenialservicetwo:
-  build: ../../dockerfiles/itest/service_two
+  xenialservicetwo:
+    build: ../../dockerfiles/itest/service_two

--- a/dockerfiles/itest/itest/Dockerfile.bionic
+++ b/dockerfiles/itest/itest/Dockerfile.bionic
@@ -26,12 +26,13 @@ RUN apt-get update && apt-get -y install \
     zlib1g-dev \
     nginx \
     liblua5.3-dev \
+    wget \
     libssl-dev \
     rsyslog
 
 # HAProxy configured with Lua scripting
 WORKDIR /
-ADD http://www.haproxy.org/download/1.7/src/haproxy-1.7.8.tar.gz /haproxy.tar.gz
+RUN wget http://www.haproxy.org/download/1.7/src/haproxy-1.7.8.tar.gz -O /haproxy.tar.gz
 RUN tar -axvf /haproxy.tar.gz
 WORKDIR /haproxy-1.7.8
 RUN make TARGET=linux26 \

--- a/dockerfiles/itest/itest/Dockerfile.bionic
+++ b/dockerfiles/itest/itest/Dockerfile.bionic
@@ -1,5 +1,8 @@
 FROM ubuntu:bionic
 
+ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
+ENV PIP_INDEX_URL=$PIP_INDEX_URL
+
 # Need Python 3.6
 RUN apt-get update > /dev/null && \
     apt-get install -y --no-install-recommends software-properties-common && \

--- a/dockerfiles/itest/itest/Dockerfile.trusty
+++ b/dockerfiles/itest/itest/Dockerfile.trusty
@@ -24,6 +24,7 @@ RUN apt-get update && apt-get -y install \
     libxml2-dev \
     libxslt-dev \
     libssl-dev \
+    wget \
     build-essential \
     zlib1g-dev
 
@@ -38,7 +39,7 @@ RUN make install INSTALL_TOP=/usr/bin/lua
 
 # Ubuntu trusty nginx and haproxy are ancient, grab newer ones
 WORKDIR /
-ADD http://www.haproxy.org/download/1.7/src/haproxy-1.7.8.tar.gz /haproxy.tar.gz
+RUN wget http://www.haproxy.org/download/1.7/src/haproxy-1.7.8.tar.gz -O /haproxy.tar.gz
 RUN tar -axvf /haproxy.tar.gz
 WORKDIR /haproxy-1.7.8
 RUN pwd

--- a/dockerfiles/itest/itest/Dockerfile.trusty
+++ b/dockerfiles/itest/itest/Dockerfile.trusty
@@ -1,5 +1,8 @@
 FROM ubuntu:14.04
 
+ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
+ENV PIP_INDEX_URL=$PIP_INDEX_URL
+
 # Need Python 3.6
 RUN apt-get update > /dev/null && \
     apt-get install -y --no-install-recommends software-properties-common && \

--- a/dockerfiles/itest/itest/Dockerfile.xenial
+++ b/dockerfiles/itest/itest/Dockerfile.xenial
@@ -27,11 +27,12 @@ RUN apt-get update && apt-get -y install \
     nginx \
     liblua5.3-dev \
     libssl-dev \
+    wget \
     rsyslog
 
 # HAProxy configured with Lua scripting
 WORKDIR /
-ADD http://www.haproxy.org/download/1.7/src/haproxy-1.7.8.tar.gz /haproxy.tar.gz
+RUN wget http://www.haproxy.org/download/1.7/src/haproxy-1.7.8.tar.gz -O /haproxy.tar.gz
 RUN tar -axvf /haproxy.tar.gz
 WORKDIR /haproxy-1.7.8
 RUN make TARGET=linux26 \

--- a/dockerfiles/itest/itest/Dockerfile.xenial
+++ b/dockerfiles/itest/itest/Dockerfile.xenial
@@ -1,5 +1,8 @@
 FROM ubuntu:xenial
 
+ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
+ENV PIP_INDEX_URL=$PIP_INDEX_URL
+
 # Need Python 3.6
 RUN apt-get update > /dev/null && \
     apt-get install -y --no-install-recommends software-properties-common && \

--- a/dockerfiles/itest/service_one/Dockerfile
+++ b/dockerfiles/itest/service_one/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:14.04
+ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
+ENV PIP_INDEX_URL=$PIP_INDEX_URL
 RUN apt-get update && apt-get install -y git python python-setuptools python-pip
 RUN git clone --branch yelp https://github.com/Yelp/hacheck
-RUN cd /hacheck && python setup.py install
+RUN cd /hacheck && pip install .
 
 RUN apt-get -y install socat
 

--- a/dockerfiles/itest/service_three/Dockerfile
+++ b/dockerfiles/itest/service_three/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:14.04
+ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
+ENV PIP_INDEX_URL=$PIP_INDEX_URL
 RUN apt-get update && apt-get install -y git python python-setuptools python-pip
 RUN git clone --branch yelp https://github.com/Yelp/hacheck
-RUN cd /hacheck && python setup.py install
+RUN cd /hacheck && pip install .
 
 # Hacheck
 EXPOSE 6666

--- a/dockerfiles/itest/service_two/Dockerfile
+++ b/dockerfiles/itest/service_two/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:14.04
+ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
+ENV PIP_INDEX_URL=$PIP_INDEX_URL
 RUN apt-get update && apt-get install -y git python python-setuptools python-pip
 RUN git clone --branch yelp https://github.com/Yelp/hacheck
-RUN cd /hacheck && python setup.py install
+RUN cd /hacheck && pip install .
 
 # Hacheck
 EXPOSE 6666

--- a/dockerfiles/trusty/Dockerfile
+++ b/dockerfiles/trusty/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:14.04
 
+ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
+ENV PIP_INDEX_URL=$PIP_INDEX_URL
+
 RUN rm -f /etc/apt/sources.list.d/proposed.list
 
 # Older versions of dh-virtualenv are buggy and don't.. work

--- a/dockerfiles/trusty/docker-compose.yml
+++ b/dockerfiles/trusty/docker-compose.yml
@@ -1,5 +1,7 @@
-trusty:
-  build: ../../dockerfiles/trusty
-  command: bash -c "cd src && tox -etrusty && dpkg-buildpackage -d -uc -us && mv ../*.deb ../dist/"
-  volumes:
-   - ../..:/work
+version: '2.4'
+services:
+  trusty:
+    build: ../../dockerfiles/trusty
+    command: bash -c "cd src && tox -etrusty && dpkg-buildpackage -d -uc -us && mv ../*.deb ../dist/"
+    volumes:
+     - ../..:/work

--- a/dockerfiles/xenial/Dockerfile
+++ b/dockerfiles/xenial/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:xenial
 
+ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
+ENV PIP_INDEX_URL=$PIP_INDEX_URL
+
 # Need Python 3.6
 RUN apt-get update > /dev/null && \
     apt-get install -y --no-install-recommends software-properties-common && \

--- a/dockerfiles/xenial/docker-compose.yml
+++ b/dockerfiles/xenial/docker-compose.yml
@@ -1,5 +1,7 @@
-xenial:
-  build: ../../dockerfiles/xenial
-  command: bash -c "cd src && tox -exenial && dpkg-buildpackage -d -uc -us && mv ../*.deb ../dist/"
-  volumes:
-   - ../..:/work
+version: '2.4'
+services:
+  xenial:
+    build: ../../dockerfiles/xenial
+    command: bash -c "cd src && tox -exenial && dpkg-buildpackage -d -uc -us && mv ../*.deb ../dist/"
+    volumes:
+     - ../..:/work

--- a/src/debian/rules
+++ b/src/debian/rules
@@ -1,6 +1,8 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
 
+PIP_INDEX_URL ?= https://pypi.yelpcorp.com/simple
+
 export DH_VIRTUALENV_INSTALL_ROOT=/opt/venvs
 
 export DH_OPTIONS
@@ -20,7 +22,7 @@ override_dh_auto_test:
 	true
 
 override_dh_virtualenv:
-	dh_virtualenv `host pypi.yelpcorp.com >/dev/null 2>&1 && echo '--extra-index-url https://pypi.yelpcorp.com/simple'` \
+	dh_virtualenv -i $(PIP_INDEX_URL) \
 	--python=/usr/bin/python3.6 --preinstall no-manylinux1 \
 	--preinstall pip==19.3.1 \
 	--preinstall pip-custom-platform --pip-tool pip-custom-platform

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -11,5 +11,5 @@ paasta-tools==0.90.4
 protobuf==2.6.1
 setuptools==37.0.0
 tox-pip-extensions==1.1.0
-backports.functools_lru_cache==1.2.1
+backports.functools_lru_cache==1.4
 mypy-extensions==0.4.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,21 @@
 [tox]
 skipsdist = true
-docker_compose_version = 1.23.2
+docker_compose_version = 1.26.2
 
 [testenv]
+# The Makefile and .travis.yml override the indexserver to the public one when
+# running outside of Yelp.
+indexserver = https://pypi.yelpcorp.com/simple
 deps =
     docker-compose=={[tox]docker_compose_version}
+setenv =
+    PIP_INDEX_URL = {env:PIP_INDEX_URL:https://pypi.yelpcorp.com/simple}
 
 [testenv:package_trusty]
 setenv =
     COMPOSE_FILE = dockerfiles/trusty/docker-compose.yml
 commands =
-    docker-compose --verbose build
+    docker-compose --verbose build --build-arg PIP_INDEX_URL={env:PIP_INDEX_URL:https://pypi.yelpcorp.com/simple}
     docker-compose run trusty
     docker-compose stop
     docker-compose rm --force
@@ -19,7 +24,7 @@ commands =
 setenv =
     COMPOSE_FILE = dockerfiles/xenial/docker-compose.yml
 commands =
-    docker-compose --verbose build
+    docker-compose --verbose build --build-arg PIP_INDEX_URL={env:PIP_INDEX_URL:https://pypi.yelpcorp.com/simple}
     docker-compose run xenial
     docker-compose stop
     docker-compose rm --force
@@ -28,7 +33,7 @@ commands =
 setenv =
     COMPOSE_FILE = dockerfiles/bionic/docker-compose.yml
 commands =
-    docker-compose --verbose build
+    docker-compose --verbose build --build-arg PIP_INDEX_URL={env:PIP_INDEX_URL:https://pypi.yelpcorp.com/simple}
     docker-compose run bionic
     docker-compose stop
     docker-compose rm --force
@@ -38,7 +43,7 @@ whitelist_externals = /bin/bash
 setenv =
     COMPOSE_FILE = dockerfiles/trusty/docker-compose.yml
 commands =
-    docker-compose --verbose build
+    docker-compose --verbose build --build-arg PIP_INDEX_URL={env:PIP_INDEX_URL:https://pypi.yelpcorp.com/simple}
     bash -c 'docker-compose run trusty chown -R `id -u`:`id -g` /work'
     docker-compose stop
     docker-compose rm --force
@@ -47,7 +52,7 @@ commands =
 setenv =
     COMPOSE_FILE = dockerfiles/itest/docker-compose-trusty.yml
 commands =
-    docker-compose --verbose build
+    docker-compose --verbose build --build-arg PIP_INDEX_URL={env:PIP_INDEX_URL:https://pypi.yelpcorp.com/simple}
     docker-compose run itest
     docker-compose stop
     docker-compose rm --force
@@ -56,7 +61,7 @@ commands =
 setenv =
     COMPOSE_FILE = dockerfiles/itest/docker-compose-xenial.yml
 commands =
-    docker-compose --verbose build
+    docker-compose --verbose build --build-arg PIP_INDEX_URL={env:PIP_INDEX_URL:https://pypi.yelpcorp.com/simple}
     docker-compose run itest
     docker-compose stop
     docker-compose rm --force
@@ -65,7 +70,7 @@ commands =
 setenv =
     COMPOSE_FILE = dockerfiles/itest/docker-compose-bionic.yml
 commands =
-    docker-compose --verbose build
+    docker-compose --verbose build --build-arg PIP_INDEX_URL={env:PIP_INDEX_URL:https://pypi.yelpcorp.com/simple}
     docker-compose run itest
     docker-compose stop
     docker-compose rm --force


### PR DESCRIPTION
Mostly for security reasons we don't want to build from public pypi
internally. We do want to use it for travis of course. Had to update
docker compose to make it pass a build arg. Copy paste of approach in
https://github.com/Yelp/nerve-tools/pull/76