### PR TITLE
Fix build by rehosting haproxy-1.7.8.tar.gz

### DIFF
--- a/dockerfiles/itest/itest/Dockerfile.bionic
+++ b/dockerfiles/itest/itest/Dockerfile.bionic
@@ -32,7 +32,7 @@ RUN apt-get update && apt-get -y install \
 
 # HAProxy configured with Lua scripting
 WORKDIR /
-RUN wget http://www.haproxy.org/download/1.7/src/haproxy-1.7.8.tar.gz -O /haproxy.tar.gz
+RUN wget https://yelp-travis-artifacts.s3.amazonaws.com/synapse-tools/haproxy-1.7.8.tar.gz -O /haproxy.tar.gz
 RUN tar -axvf /haproxy.tar.gz
 WORKDIR /haproxy-1.7.8
 RUN make TARGET=linux26 \

--- a/dockerfiles/itest/itest/Dockerfile.trusty
+++ b/dockerfiles/itest/itest/Dockerfile.trusty
@@ -39,7 +39,7 @@ RUN make install INSTALL_TOP=/usr/bin/lua
 
 # Ubuntu trusty nginx and haproxy are ancient, grab newer ones
 WORKDIR /
-RUN wget http://www.haproxy.org/download/1.7/src/haproxy-1.7.8.tar.gz -O /haproxy.tar.gz
+RUN wget https://yelp-travis-artifacts.s3.amazonaws.com/synapse-tools/haproxy-1.7.8.tar.gz -O /haproxy.tar.gz
 RUN tar -axvf /haproxy.tar.gz
 WORKDIR /haproxy-1.7.8
 RUN pwd

--- a/dockerfiles/itest/itest/Dockerfile.xenial
+++ b/dockerfiles/itest/itest/Dockerfile.xenial
@@ -32,7 +32,7 @@ RUN apt-get update && apt-get -y install \
 
 # HAProxy configured with Lua scripting
 WORKDIR /
-RUN wget http://www.haproxy.org/download/1.7/src/haproxy-1.7.8.tar.gz -O /haproxy.tar.gz
+RUN wget https://yelp-travis-artifacts.s3.amazonaws.com/synapse-tools/haproxy-1.7.8.tar.gz -O /haproxy.tar.gz
 RUN tar -axvf /haproxy.tar.gz
 WORKDIR /haproxy-1.7.8
 RUN make TARGET=linux26 \


### PR DESCRIPTION
It appears that Travis is either blocked by haproxy.org or is blocking it itself:
https://travis-ci.community/t/access-to-external-git-repo-not-possible-anymore/8975

Let's switch to a re-hosted version of the same tarball to fix this.