### PR TITLE
Only disable the nginx listener when a namespace is Envoy-only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ src/.cache/
 bintray.json
 *.deb
 .mypy_cache/
+/venv


### PR DESCRIPTION
Internal ticket: MESH-931

The current behavior is to disable both the haproxy and nginx listener when a namespace is Envoy-only. There's a race condition when disabling a namespace where haproxy (the service that listens on a UNIX socket) reloads before nginx (the service that listens on the proxy port and proxies to haproxy) which results in 503s being served for about 10 seconds:

```
$ curl localhost:20139
<html>[...]

$ curl localhost:20139
503 Service Unavailable
Served by haproxy-synapse on 10-65-79-67-useast1aprod.useast1-prod.yelpcorp.com.

$ curl localhost:20139
503 Service Unavailable
Served by haproxy-synapse on 10-65-79-67-useast1aprod.useast1-prod.yelpcorp.com.

$ curl localhost:20139
curl: (7) Failed to connect to localhost port 20139: Connection refused
```

This is bad because if nginx and envoy are sharing the port, we may serve 503s from nginx for a few seconds depending on how the traffic is split.

The new approach is to just keep the haproxy listener around and only tear down the nginx listener. This avoids complex coordination that would be required to ensure they get torn down / brought up in the correct order to avoid serving errors, and should be effectively equivalent since nothing will be using the haproxy UNIX socket.

## Verification

Here's what a diff to the synapse config looks like now when disabling a namespace:

```diff
--- before      2020-08-13 09:59:53.946522493 -0700
+++ after       2020-08-13 10:05:27.145168974 -0700
@@ -30346,32 +30320,6 @@
             },
             "use_previous_backends": false
         },
-        "example_happyhour.envoy.nginx_listener": {
-            "default_servers": [
-                {
-                    "host": "unix",
-                    "port": "/var/run/synapse/sockets/example_happyhour.envoy.prxy"
-                }
-            ],
-            "discovery": {
-                "method": "base"
-            },
-            "file_output": {
-                "disabled": true
-            },
-            "haproxy": {
-                "disabled": true
-            },
-            "nginx": {
-                "mode": "tcp",
-                "port": 20139,
-                "server": [
-                    "proxy_timeout 3610s",
-                    "proxy_protocol on"
-                ]
-            },
-            "use_previous_backends": true
-        },
         "example_happyhour.main": {
             "default_servers": [],
             "discovery": {
```

I manually tested a built package when toggling off a namespace and it cleanly goes from working to connection refused:
```
$ while :; do curl -sSI localhost:20139/status | head -n1; sleep 0.05; done
HTTP/1.1 200 OK
HTTP/1.1 200 OK
HTTP/1.1 200 OK
HTTP/1.1 200 OK
HTTP/1.1 200 OK
HTTP/1.1 200 OK
HTTP/1.1 200 OK
curl: (7) Failed to connect to localhost port 20139: Connection refused
curl: (7) Failed to connect to localhost port 20139: Connection refused
curl: (7) Failed to connect to localhost port 20139: Connection refused
curl: (7) Failed to connect to localhost port 20139: Connection refused
curl: (7) Failed to connect to localhost port 20139: Connection refused
curl: (7) Failed to connect to localhost port 20139: Connection refused
curl: (7) Failed to connect to localhost port 20139: Connection refused
```