### PR TITLE
don't write an empty ip map if the kubelet api returns an error

### DIFF
--- a/src/debian/changelog
+++ b/src/debian/changelog
@@ -1,3 +1,22 @@
+synapse-tools (0.15.2) xenial; urgency=medium
+
+  * don't write an empty ip map if the kubelet api returns an error
+
+    Part of kubelet's lifecycle involves `systemctl restart` on certain
+    updates.  This makes the local kubelet api unavailable, and the
+    generate
+    ip mapping script will write an empty map file.
+
+    This involves two changes:
+    1. split mesos and k8s instance discovery funtions,
+    since previously the function decided "error from k8s api => we're on a
+    mesos box". Now, a --k8s flag will tell the script to use k8s
+    instance discovery, otherwise it will default to mesos
+    2. do not take any further action if the kubelet api returns an error on
+    a k8s host
+
+ -- Matthew Bentley <bentley@yelp.com>  Thu, 20 Aug 2020 12:41:29 -0700
+
 synapse-tools (0.15.1) xenial; urgency=medium
 
   * Don't tear down the haproxy listener when Envoy is disabled for a

--- a/src/setup.py
+++ b/src/setup.py
@@ -14,7 +14,7 @@ def get_install_requires():
 
 setup(
     name='synapse-tools',
-    version='0.15.1',
+    version='0.15.2',
     provides=['synapse_tools'],
     author='John Billings',
     author_email='billings@yelp.com',

--- a/src/synapse_tools/generate_container_ip_map.py
+++ b/src/synapse_tools/generate_container_ip_map.py
@@ -60,7 +60,7 @@ def extract_taskid_and_ip_mesos(
     return service_ips_and_ids
 
 
-def extract_taskid_and_ip_k8s():
+def extract_taskid_and_ip_k8s() -> Iterable[Tuple[str, str]]:
     service_ips_and_ids = []
 
     node_info = requests.get("http://169.254.255.254:10255/pods/").json()

--- a/src/synapse_tools/generate_container_ip_map.py
+++ b/src/synapse_tools/generate_container_ip_map.py
@@ -178,7 +178,7 @@ def main() -> None:
         try:
             service_ips_and_ids = extract_taskid_and_ip_k8s()
         except Exception as e:
-            print(e.message, file=sys.stderr)
+            print(e, file=sys.stderr)
             return
     else:
         service_ips_and_ids = extract_taskid_and_ip_mesos(get_docker_client())


### PR DESCRIPTION
Part of kubelet's lifecycle involves `systemctl restart` on certain
updates.  This makes the local kubelet api unavailable, and the generate
ip mapping script will write an empty map file.

This involves two changes:
1. split mesos and k8s instance discovery funtions, since previously the
function decided "error from k8s api => we're on a mesos box". Now, a
--k8s flag will tell the script to use k8s instance discovery, otherwise
it will default to mesos
2. do not take any further action if the kubelet api returns an error on
a k8s host

rollout for this change will require bumping the package at the same time as adding the `--k8s` flag on kube hosts