### PR TITLE
Add reuseport_enable toggle option for nginx listeners

### DIFF
--- a/dockerfiles/itest/itest/srv-configs/service_mesh/envoy_migration.yaml
+++ b/dockerfiles/itest/itest/srv-configs/service_mesh/envoy_migration.yaml
@@ -1,2 +1,3 @@
 migration_enabled: false
+reuseport_enabled: false
 namespaces: {}


### PR DESCRIPTION
Internal ticket: MESH-862

Using the same config namespace as #86, this PR adds a `reuseport_enable` option that will configure all nginx listeners to use the SO_REUSEPORT socket option.

```yaml
migration_enabled: {true|false}
reuseport_enabled: {true|false}
namespaces:
    {namespace}:
        state: {synapse|dual|envoy}
```

The new option respects the existing `migration_enable` option as a "master kill switch", meaning if `migration_enable` is False, then SO_REUSEPORT will never be used.

## Testing Done

* Existing tests pass
* Added assert statements to verify the existence of the `reuseport` option in nginx listeners
* Added tests to cover the permutations of `migration_enabled` and `reuseport_enabled`