### PR TITLE
Fix nginx reload doesn't work second time

### DIFF
--- a/src/debian/synapse-tools.links
+++ b/src/debian/synapse-tools.links
@@ -2,3 +2,4 @@ opt/venvs/synapse-tools/bin/configure_synapse usr/bin/configure_synapse
 opt/venvs/synapse-tools/bin/generate_container_ip_map usr/bin/generate_container_ip_map
 opt/venvs/synapse-tools/bin/haproxy_synapse_reaper usr/bin/haproxy_synapse_reaper
 opt/venvs/synapse-tools/bin/synapse_qdisc_tool usr/bin/synapse_qdisc_tool
+opt/venvs/synapse-tools/bin/synapse-tools-reload-nginx.sh usr/bin/synapse-tools-reload-nginx

--- a/src/setup.py
+++ b/src/setup.py
@@ -31,4 +31,7 @@ setup(
             'synapse_qdisc_tool=synapse_tools.haproxy.qdisc_tool:main',
         ],
     },
+    scripts=[
+        "synapse-tools-reload-nginx.sh",
+    ],
 )

--- a/src/synapse-tools-reload-nginx.sh
+++ b/src/synapse-tools-reload-nginx.sh
@@ -1,0 +1,75 @@
+#! /usr/bin/env bash
+
+set -ue -o pipefail
+
+pidfile="$1"
+
+# See http://nginx.org/en/docs/control.html#upgrade for details about nginx
+# reload process.
+
+# At this moment we have the current master with PID in `$pidfile` (and its workers).
+# We also might have the old master with PID in `$pidfile.oldbin` (and its
+# workers) are still gracefully shutting down after the previous reload.
+
+# If the old master process from the previous reload is still running, kill it
+if [ -e "$pidfile.oldbin" ] && pkill -0 --pidfile "$pidfile.oldbin" -f 'nginx: master'; then
+    oldpid=$(cat "$pidfile.oldbin") || true  # The old master could quit at any moment
+    if [ -e "$pidfile.oldbin" ]; then
+        # Tell the old master and its workers to fast shutdown.
+        kill -TERM "-${oldpid}" || true  # The old master could quit at any moment
+        died=0
+        for _ in $(seq 50); do
+            sleep .1
+            if ! kill -0 "$oldpid"; then
+                died=1
+                break
+            fi
+        done
+        if [ $died -eq 0 ]; then
+            # 5 seconds is more than enough to shutdown, hard kill the old
+            # master and all its workers.
+            kill -KILL "-${oldpid}" || true  # The old master could quit at any moment
+            sleep 1
+        fi
+    fi
+fi
+
+curpid=$(cat "$pidfile")
+
+# Tell the current master to launch a new master and wait for it to be running
+# The new master is expected to rename `$pidfile` into `$pidfile.oldbin`
+# and write its PID into `$pidfile`.  So, at the end there should be
+# `$pidfile` with the new master's PID and `$pidfile.oldbin` with the
+# current master's PID.
+kill -USR2 "$curpid"
+for _ in $(seq 50); do
+    sleep .1
+    newpid=$(cat "$pidfile")
+    if [ "$curpid" -ne "$newpid" ]; then
+        break
+    fi
+done
+
+# If the new master didn't manage to write its pid into `$pidfile` during
+# the previous 5 sec, then something is very wrong with it (most likely an
+# invalid config file), so just give up.
+if [ "$curpid" -eq "$newpid" ]; then
+    exit 1
+fi
+
+# At this moment we have the current master with its PID in
+# `$pidfile.oldbin` (and its workers) and the new master with its PID in
+# `$pidfile` (and its workers).  Both are accepting new conections.
+# Now let's gracefully shutdown the current master and its workers, so only
+# the new master and its workers will accept and process the new
+# connections.  The current master and its workers will be alive until all
+# their already accepted connections are alive, which could take a lot
+# of time.
+
+curpid=$(cat "$pidfile.oldbin")
+
+# Tell the current master to gracefully shutdown its worker processes
+kill -WINCH "$curpid"
+
+# Tell the current master to gracefully shutdown
+kill -QUIT "$curpid"

--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -207,8 +207,7 @@ def set_defaults(
         ('nginx_prefix', '/var/run/synapse/nginx_temp'),
         ('nginx_config_path', '/var/run/synapse/nginx.cfg'),
         ('nginx_pid_file_path', '/var/run/synapse/nginx.pid'),
-        ('nginx_reload_script',
-            r"""/bin/bash -c 'set -ue -o pipefail; q() { pidfile=$1; oldpid=$(cat $pidfile); kill -USR2 $oldpid; sleep 2; newpid=$(cat $pidfile); if [ $oldpid -eq $newpid ]; then return 1; fi; kill -WINCH $(cat $pidfile.oldbin); kill -QUIT $(cat $pidfile.oldbin); }; q $0'"""),
+        ('nginx_reload_script', '/usr/bin/synapse-tools-reload-nginx'),
         ('nginx_proxy_proto', False),
         # http://nginx.org/en/docs/control.html#upgrade
         # This is apparently how you gracefully reload the binary ...


### PR DESCRIPTION
During reload `synapse-tools` restarts `nginx` gracefully, which means
that after the restart the new `nginx` instance accepts new connections, but
the old `nginx` instance exists until all previously established connections are alive.
Since we have some long-running connections, the old instances could run
for very long time.

The issue with that is that `nginx` doesn't restart the second time if
the old instance is still alive.

This PR fixes that by force-killing the old instance before doing the
`nginx` restart.

While here I've also moved all reload logic into a script.