### PR TITLE
MESH-1010 Default to Envoy mode

### DIFF
--- a/src/synapse_tools/configure_synapse.py
+++ b/src/synapse_tools/configure_synapse.py
@@ -608,7 +608,7 @@ def generate_configuration(
 
         namespace_is_envoy_only = (
             envoy_migration_config['migration_enabled'] and
-            envoy_migration_config['namespaces'].get(service_name, {'state': 'synapse'}).get('state') == 'envoy'
+            envoy_migration_config['namespaces'].get(service_name, {'state': 'envoy'}).get('state') == 'envoy'
         )
 
         # Note that at this point proxy_port can be:


### PR DESCRIPTION
if a namespace is not defined on envoy_migration.yaml, let's default to Envoy instead of Synapse.